### PR TITLE
i161: Allow use of deriv in delay models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: Ode Generation and Integration
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: person("Rich", "FitzJohn", role = c("aut", "cre"),
                   email = "rich.fitzjohn@gmail.com")
 Description: Generate systems of ODEs and integrate them.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin 0.2.1
+
+* Continuous time models with delays can now return derivatives ([#161](https://github.com/mrc-ide/odin/issues/161), [#162](https://github.com/mrc-ide/odin/issues/162))
+
 # odin 0.2.0
 
 A complete rewrite of the odin engine, designed to increase future maintainability but have few user-visible effects.  In brief, this does add

--- a/R/generate_c_class.R
+++ b/R/generate_c_class.R
@@ -115,13 +115,9 @@ odin_c_class_deriv <- function(features, env = .GlobalEnv) {
     NULL
   } else {
     args <- alist(t =, y =)
-    if (features$has_delay) {
-      body <- quote(stop("Can't call deriv() on delay models"))
-    } else {
-      body <- call(".Call", quote(private$core$rhs_r), quote(private$ptr),
-                   quote(as_numeric(t)), quote(as_numeric(y)),
-                   PACKAGE = quote(private$dll))
-    }
+    body <- call(".Call", quote(private$core$rhs_r), quote(private$ptr),
+                 quote(as_numeric(t)), quote(as_numeric(y)),
+                 PACKAGE = quote(private$dll))
     as_function(args, r_expr_block(body), env)
   }
 }

--- a/R/generate_c_compiled.R
+++ b/R/generate_c_compiled.R
@@ -160,10 +160,8 @@ generate_c_compiled_create <- function(eqs, dat, rewrite) {
     body$add(user)
   }
 
-  if (dat$features$has_delay) {
-    body$add("%s = %s;",
-             rewrite(dat$meta$initial_time),
-             if (dat$features$discrete) "NA_INTEGER" else "NA_REAL")
+  if (dat$features$has_delay && !dat$features$discrete) {
+    body$add("%s = NA_REAL;", rewrite(dat$meta$initial_time))
   }
 
   body$add("SEXP %s = PROTECT(R_MakeExternalPtr(%s, R_NilValue, R_NilValue));",

--- a/R/generate_c_compiled.R
+++ b/R/generate_c_compiled.R
@@ -160,6 +160,12 @@ generate_c_compiled_create <- function(eqs, dat, rewrite) {
     body$add(user)
   }
 
+  if (dat$features$has_delay) {
+    body$add("%s = %s;",
+             rewrite(dat$meta$initial_time),
+             if (dat$features$discrete) "NA_INTEGER" else "NA_REAL")
+  }
+
   body$add("SEXP %s = PROTECT(R_MakeExternalPtr(%s, R_NilValue, R_NilValue));",
            ptr, internal)
   body$add("R_RegisterCFinalizer(%s, %s);", ptr, dat$meta$c$finalise)
@@ -263,7 +269,13 @@ generate_c_compiled_deriv_dde <- function(dat) {
 
 generate_c_compiled_rhs_r <- function(dat, rewrite) {
   discrete <- dat$features$discrete
-  time_access <- if (discrete) "INTEGER" else "REAL"
+  if (discrete) {
+    time_access <- "INTEGER"
+    time_type <- "int"
+  } else {
+    time_access <- "REAL"
+    time_type <- "double"
+  }
   body <- collector()
   body$add("SEXP %s = PROTECT(allocVector(REALSXP, LENGTH(%s)));",
           dat$meta$result, dat$meta$state)
@@ -286,9 +298,32 @@ generate_c_compiled_rhs_r <- function(dat, rewrite) {
     body$add("GetRNGstate();")
   }
 
-  body$add("%s(%s, %s(%s)[0], REAL(%s), REAL(%s), %s);",
-           dat$meta$c$rhs, dat$meta$internal, time_access, dat$meta$time,
-           dat$meta$state, dat$meta$result, dat$meta$output)
+  eval_rhs <- sprintf_safe(
+    "%s(%s, %s(%s)[0], REAL(%s), REAL(%s), %s);",
+    dat$meta$c$rhs, dat$meta$internal, time_access, dat$meta$time,
+    dat$meta$state, dat$meta$result, dat$meta$output)
+
+  ## In order to run the derivative calculation safely, we have to set
+  ## the initial time.  But in order to make this safe, we need to put
+  ## that back later (because otherwise after the first evaluation of
+  ## the derivative it might look like we have the ability to compute
+  ## derivatives with history but that history does not actually exist
+  ## yet).
+  if (dat$features$has_delay) {
+    initial_time <- rewrite(dat$meta$initial_time)
+    set_initial_time <- c(
+      sprintf_safe("const %s %s = %s;",
+                   time_type, dat$meta$initial_time, initial_time),
+      c_expr_if(sprintf_safe("ISNA(%s)", dat$meta$initial_time),
+                sprintf_safe("%s = %s(%s)[0];",
+                             initial_time, time_access, dat$meta$time)))
+    reset_initial_time <-
+      c_expr_if(sprintf_safe("ISNA(%s)", dat$meta$initial_time),
+                sprintf_safe("%s = %s;", initial_time, dat$meta$initial_time))
+    body$add(c(set_initial_time, eval_rhs, reset_initial_time))
+  } else {
+    body$add(eval_rhs)
+  }
 
   if(dat$features$has_stochastic) {
     body$add("PutRNGstate();")

--- a/R/generate_c_utils.R
+++ b/R/generate_c_utils.R
@@ -76,12 +76,18 @@ c_type_info <- function(storage_type) {
 }
 
 
-c_expr_if <- function(condition, a, b) {
-  c(sprintf_safe("if (%s) {", condition),
-    paste0("  ", c_flatten_eqs(a)),
-    "} else {",
-    paste0("  ", c_flatten_eqs(b)),
-    "}")
+c_expr_if <- function(condition, a, b = NULL) {
+  if (is.null(b)) {
+    c(sprintf_safe("if (%s) {", condition),
+      paste0("  ", c_flatten_eqs(a)),
+      "}")
+  } else {
+    c(sprintf_safe("if (%s) {", condition),
+      paste0("  ", c_flatten_eqs(a)),
+      "} else {",
+      paste0("  ", c_flatten_eqs(b)),
+      "}")
+  }
 }
 
 

--- a/R/generate_r.R
+++ b/R/generate_r.R
@@ -64,9 +64,8 @@ generate_r_create <- function(eqs, dat, env, rewrite) {
   alloc <- call("<-", as.name(dat$meta$internal),
                 quote(new.env(parent = emptyenv())))
   eqs_create <- r_flatten_eqs(eqs[dat$components$create$equations])
-  if (dat$features$has_delay) {
-    na <- if (dat$features$discrete) NA_integer_ else NA_real_
-    initial_time <- call("<-", rewrite(dat$meta$initial_time), na)
+  if (dat$features$has_delay && !dat$features$discrete) {
+    initial_time <- call("<-", rewrite(dat$meta$initial_time), NA_real_)
   } else {
     initial_time <- NULL
   }

--- a/R/generate_r_class.R
+++ b/R/generate_r_class.R
@@ -109,8 +109,9 @@ generate_r_class <- function(core, dat, env) {
 
       deriv = if (!dat$features$discrete) {
         function(t, y) {
-          if (private$delay) {
-            stop("Can't call deriv() on delay models")
+          if (private$delay && is.na(private$data$initial_t)) {
+            private$data$initial_t <- t[[1]]
+            on.exit(private$data$initial_t <- NA_real_)
           }
           ret <- private$core$rhs_dde(t, y, private$data)
           if (!is.null(private$core$output)) {

--- a/tests/testthat/run/test-run-examples.R
+++ b/tests/testthat/run/test-run-examples.R
@@ -32,23 +32,21 @@ test_that("basic interface", {
 
     ## expect_equal(mod_c$init,
     ##              if (has_delay) NULL else unname(mod_r$initial(t0)))
-    expect_equal(mod_c$initial(t0), unname(mod_r$initial(t0)),
-                 check.attributes = FALSE)
+    expect_equivalent(mod_c$initial(t0), unname(mod_r$initial(t0)))
 
     priv <- r6_private(mod_c)
     has_output <- priv$n_out > 0
 
     deriv_c <- mod_c$deriv(t0, mod_c$initial(t0))
     deriv_r <- mod_r$derivs(t0, mod_c$initial(t0))
-    expect_equal(deriv_c, deriv_r[[1L]], check.attributes = FALSE)
+    expect_equivalent(deriv_c, deriv_r[[1L]])
 
     if (has_output) {
-      ## The check.attributes is necessary because otherwise testthat
-      ## gives entirely meaningless error messages on attribute
-      ## differences (as it looks for differences in the values
-      ## themselves).
-      expect_equal(attr(deriv_c, "output", exact = TRUE), deriv_r[[2L]],
-                   check.attributes = FALSE)
+      ## Using expect_equivalent to skip attributes is necessary
+      ## because otherwise testthat gives entirely meaningless error
+      ## messages on attribute differences (as it looks for
+      ## differences in the values themselves).
+      expect_equivalent(attr(deriv_c, "output", exact = TRUE), deriv_r[[2L]])
     } else {
       expect_null(attr(deriv_c, "output"))
     }
@@ -60,7 +58,7 @@ test_that("basic interface", {
     res_r <- run_model(mod_r, t)
     res_c <- mod_c$run(t)
     if (!on_appveyor()) {
-      expect_equal(res_c, res_r, check.attributes = FALSE, tolerance = tol)
+      expect_equivalent(res_c, res_r, tolerance = tol)
     }
 
     y <- mod_c$transform_variables(res_c)
@@ -186,7 +184,7 @@ test_that("lv", {
   res_r <- run_model(mod_r, t, pars)
   res_c <- mod_c$run(t)
 
-  expect_equal(res_c, res_r, check.attributes = FALSE)
+  expect_equivalent(res_c, res_r)
   y <- mod_c$transform_variables(res_c)
   expect_is(y, "list")
   expect_equal(names(y), c(TIME, "y"))

--- a/tests/testthat/run/test-run-examples.R
+++ b/tests/testthat/run/test-run-examples.R
@@ -38,24 +38,19 @@ test_that("basic interface", {
     priv <- r6_private(mod_c)
     has_output <- priv$n_out > 0
 
-    if (has_delay) {
-      expect_error(mod_c$deriv(t0, mod_c$init),
-                   "Can't call deriv() on delay models", fixed = TRUE)
-    } else {
-      deriv_c <- mod_c$deriv(t0, mod_c$initial(t0))
-      deriv_r <- mod_r$derivs(t0, mod_c$initial(t0))
-      expect_equal(deriv_c, deriv_r[[1L]], check.attributes = FALSE)
+    deriv_c <- mod_c$deriv(t0, mod_c$initial(t0))
+    deriv_r <- mod_r$derivs(t0, mod_c$initial(t0))
+    expect_equal(deriv_c, deriv_r[[1L]], check.attributes = FALSE)
 
-      if (has_output) {
-        ## The check.attributes is necessary because otherwise testthat
-        ## gives entirely meaningless error messages on attribute
-        ## differences (as it looks for differences in the values
-        ## themselves).
-        expect_equal(attr(deriv_c, "output", exact = TRUE), deriv_r[[2L]],
-                     check.attributes = FALSE)
-      } else {
-        expect_null(attr(deriv_c, "output"))
-      }
+    if (has_output) {
+      ## The check.attributes is necessary because otherwise testthat
+      ## gives entirely meaningless error messages on attribute
+      ## differences (as it looks for differences in the values
+      ## themselves).
+      expect_equal(attr(deriv_c, "output", exact = TRUE), deriv_r[[2L]],
+                   check.attributes = FALSE)
+    } else {
+      expect_null(attr(deriv_c, "output"))
     }
 
     ## These tolerances work for me locally on OSX, Windows and Linux,

--- a/tests/testthat/run/test-run-general.R
+++ b/tests/testthat/run/test-run-general.R
@@ -268,9 +268,8 @@ test_that("time dependent initial conditions", {
   mod <- gen()
 
   ## Initial conditions get through here:
-  expect_equal(mod$initial(0), 1, check.attributes = FALSE)
-  expect_equal(mod$initial(1), cos(1) * 2,
-               check.attributes = FALSE)
+  expect_equivalent(mod$initial(0), 1)
+  expect_equivalent(mod$initial(1), cos(1) * 2)
 
   t <- seq(0, 4 * pi, length.out = 101)
   y <- mod$run(t, atol = 1e-8, rtol = 1e-8)
@@ -780,7 +779,7 @@ test_that("overlapping graph", {
     list(y * p, p + p2)
   }
   cmp <- deSolve::ode(1, tt, f, NULL)
-  expect_equal(mod$run(tt), cmp, check.attributes = FALSE)
+  expect_equivalent(mod$run(tt), cmp)
 })
 
 test_that("sum over one dimension", {

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -14,7 +14,7 @@ test_that("generate package", {
   t <- seq(0, 10, length.out = 100)
   y_c <- mod$run(t)
   y_r <- run_model(cmp, t)
-  expect_equal(y_c[, 2:4], y_r[, 2:4], check.attributes = FALSE)
+  expect_equivalent(y_c[, 2:4], y_r[, 2:4])
 
   ## Provides a loose check that the ir/coef bits work:
   expect_setequal(coef(res$env$sir)$name, c("I0", "beta"))


### PR DESCRIPTION
This PR allows the `deriv()` method to be used with models that include delays.

Previously this was disabled because we need to be careful about treatment of the history.  However, it's not too hard to do something along the lines of the Right Thing:

* if the model has never been run, there is no history, and so `deriv()` should treat this as if it's still burning the delays in (i.e., use the initial conditions)
* if the model has been run, then running `deriv()` should not affect the history (especially once model resuming is implemented - #141) so we should just use the history stored in the model

In order to support this:

1. the `create` phase initialises the `initial_t` member to `NA` (previously was default-initialised to zero which is not ideal)
2. when using the deriv wrapper from R, we check that the initial time is NA and if so it means that the model has not been run. In that case we *temporarily* set the `initial_t` element to the same time as current so that we always compute the delay-free derivatives - on exit we reset the `initial_t` to zero.

Most of the PR is a contrived test case that checks this is all reasonable.
