### PR TITLE
GH-171: Better error messages for empty input

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: Ode Generation and Integration
-Version: 0.2.4
+Version: 0.2.5
 Authors@R: person("Rich", "FitzJohn", role = c("aut", "cre"),
                   email = "rich.fitzjohn@gmail.com")
 Description: Generate systems of ODEs and integrate them.

--- a/R/odin_parse.R
+++ b/R/odin_parse.R
@@ -38,5 +38,5 @@ odin_parse <- function(x, type = NULL, options = NULL) {
 ##' @rdname odin_parse
 odin_parse_ <- function(x, options = NULL, type = NULL) {
   options <- odin_options(options = options)
-  ir_parse(x, options)
+  ir_parse(x, options, type)
 }

--- a/R/odin_preprocess.R
+++ b/R/odin_preprocess.R
@@ -64,7 +64,7 @@ odin_preprocess_detect <- function(x, type = NULL) {
         }
       }
       as <- type
-    } else if (length(x) > 1L || grepl("([\n;=()]|<-)", x)) {
+    } else if (length(x) != 1L || grepl("([\n;=()]|<-)", x)) {
       as <- "text"
     } else if (file.exists(x)) {
       as <- "file"

--- a/tests/testthat/test-odin-validate.R
+++ b/tests/testthat/test-odin-validate.R
@@ -38,3 +38,13 @@ test_that("invalid R", {
   expect_is(res$error, "error")
   expect_equal(res$messages, list())
 })
+
+
+test_that("type is passed along", {
+  expect_equal(odin_validate("", "text")$error$message,
+               "Did not find a deriv() or an update() call",
+               fixed = TRUE)
+  expect_equal(odin_validate(character(0), "text")$error$message,
+               "Did not find a deriv() or an update() call",
+               fixed = TRUE)
+})

--- a/tests/testthat/test-preprocess.R
+++ b/tests/testthat/test-preprocess.R
@@ -52,3 +52,9 @@ test_that("detect invalid type", {
   expect_error(odin_preprocess_detect(quote(x), "file"),
                "Invalid input for odin - expected file")
 })
+
+
+test_that("handle empty input", {
+  ## Previously errored
+  expect_equal(odin_preprocess_detect(character(0)), "text")
+})


### PR DESCRIPTION
Found in work on odin.ui - this fixes a couple of corner cases when different types of "empty" string are passed in.

Fixes #171 