### PR TITLE
mrc-511: Support for 2-arg round

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin 1.0.2
+
+* Support for 2-argument round (e.g., `round(1.23, 1)` is 1.2), and enforce the same 0.5 rounding behaviour as R when used from C (`mrc-511`, #116, #179)
+
 # odin 1.0.0
 
 * Initial release to CRAN

--- a/R/common.R
+++ b/R/common.R
@@ -90,7 +90,7 @@ FUNCTIONS <- list(
   lchoose = 2L,
   sign = 1L,
   ## Rounding
-  round = 1L,
+  round = c(1L, 2L),
   trunc = 1L,
   floor = 1L,
   ceil = 1L,

--- a/R/generate_c_sexp.R
+++ b/R/generate_c_sexp.R
@@ -34,6 +34,10 @@ generate_c_sexp <- function(x, data, meta, supported) {
       ret <- sprintf("%s(%s)", fn, paste(values, collapse = ", "))
     } else if (fn == "log" && length(values) == 2L) {
       ret <- sprintf("(log(%s) / log(%s))", values[[1L]], values[[2L]])
+    } else if (fn == "round") {
+      ## ensures same rounding behaviour of 0.5 as R:
+      digits <- if (length(values) == 2L) values[[2L]] else 0
+      ret <- sprintf("fround(%s, %s)", values[[1L]], digits)
     } else if (fn == "min" || fn == "max") {
       ret <- c_fold_call(paste0("f", fn), values)
     } else if (fn == "sum" || fn == "odin_sum") {

--- a/tests/testthat/run/test-run-library.R
+++ b/tests/testthat/run/test-run-library.R
@@ -106,3 +106,33 @@ test_that("%/%", {
   expect_equal(res[, "q3"],  tt %/% -q)
   expect_equal(res[, "q4"], -tt %/% -q)
 })
+
+
+test_that("2-arg round", {
+  gen <- odin({
+    deriv(x) <- 1
+    initial(x) <- 1
+    output(y) <- TRUE
+    output(z) <- TRUE
+    n <- user(0)
+    y <- round(t, n)
+    z <- round(t)
+  })
+
+  mod0 <- gen(0)
+  mod1 <- gen(1)
+  mod2 <- gen(2)
+
+  tt <- seq(0, 1, length.out = 101)
+  yy0 <- mod0$run(tt)
+  yy1 <- mod1$run(tt)
+  yy2 <- mod2$run(tt)
+
+  expect_equal(yy0[, "z"], round(tt))
+  expect_equal(yy1[, "z"], round(tt))
+  expect_equal(yy2[, "z"], round(tt))
+
+  expect_equal(yy0[, "y"], round(tt, 0))
+  expect_equal(yy1[, "y"], round(tt, 1))
+  expect_equal(yy2[, "y"], round(tt, 2))
+})


### PR DESCRIPTION
This had previously been implemented following #116 in the old version, but never merged into master before the rewrite