### PR TITLE
mrc-1433: start support for a safe mode

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,6 @@ Suggests:
     rmarkdown,
     testthat
 VignetteBuilder: knitr
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 Encoding: UTF-8
 Language: en-GB

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.0.2
+Version: 1.0.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin 1.0.3
+
+* Start on a "safe" mode for C models, currently just checking that random binomial draw probabilities lie between 0 and 1 (`mrc-1433`)
+
 # odin 1.0.2
 
 * Support for 2-argument round (e.g., `round(1.23, 1)` is 1.2), and enforce the same 0.5 rounding behaviour as R when used from C (`mrc-511`, #116, #179)

--- a/R/generate_c.R
+++ b/R/generate_c.R
@@ -71,7 +71,9 @@ generate_c_meta <- function(base, internal) {
 
 generate_c_code <- function(dat, options, package) {
   dat$meta$c <- generate_c_meta(dat$config$base, dat$meta$internal)
-  dat$meta$c$options <- list(safe = options$safe)
+  ## This is fairly ugly; we need to access this somewhere and the
+  ## metadata seems an ok place to do it.
+  dat$meta$c$options <- list(safe = dat$features$safe)
 
   if (dat$features$has_delay) {
     dat$data$elements[[dat$meta$c$use_dde]] <-

--- a/R/generate_c.R
+++ b/R/generate_c.R
@@ -71,6 +71,7 @@ generate_c_meta <- function(base, internal) {
 
 generate_c_code <- function(dat, options, package) {
   dat$meta$c <- generate_c_meta(dat$config$base, dat$meta$internal)
+  dat$meta$c$options <- list(safe = options$safe)
 
   if (dat$features$has_delay) {
     dat$data$elements[[dat$meta$c$use_dde]] <-

--- a/R/generate_c_compiled.R
+++ b/R/generate_c_compiled.R
@@ -728,6 +728,12 @@ generate_c_compiled_library <- function(dat, is_package) {
     }
   }
 
+  if (dat$meta$c$options$safe) {
+    if ("rbinom" %in% used) {
+      v <- c("safe_rbinom", v)
+    }
+  }
+
   v <- unique(v)
   msg <- setdiff(v, names(lib$declarations))
   if (length(msg) > 0L) {

--- a/R/generate_c_sexp.R
+++ b/R/generate_c_sexp.R
@@ -59,6 +59,13 @@ generate_c_sexp <- function(x, data, meta, supported) {
       } else if (!any(c(names(FUNCTIONS), supported) == fn)) {
         stop(sprintf("unsupported function '%s' [odin bug]", fn)) # nocov
       }
+
+      if (meta$c$options$safe) {
+        ## Eventually more things will be added here.
+        if (fn == "Rf_rbinom") {
+          fn <- "safe_rbinom"
+        }
+      }
       ret <- sprintf("%s(%s)", fn, paste(values, collapse = ", "))
     }
     ret

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -10,7 +10,7 @@ ir_parse <- function(x, options, type = NULL) {
 
   ## Data elements:
   config <- ir_parse_config(eqs, base, root, source)
-  features <- ir_parse_features(eqs, config, source)
+  features <- ir_parse_features(eqs, config, source, options$safe)
 
   variables <- ir_parse_find_variables(eqs, features$discrete, source)
 
@@ -405,7 +405,7 @@ ir_parse_packing_internal <- function(names, rank, len, variables,
 ## A downside of the approach here is that we do make the checks in a
 ## few different places.  It might be worth trying to shift more of
 ## this classification into the initial equation parsing.
-ir_parse_features <- function(eqs, config, source) {
+ir_parse_features <- function(eqs, config, source, safe) {
   is_update <- vlapply(eqs, function(x) identical(x$lhs$special, "update"))
   is_deriv <- vlapply(eqs, function(x) identical(x$lhs$special, "deriv"))
   is_output <- vlapply(eqs, function(x) identical(x$lhs$special, "output"))
@@ -433,7 +433,8 @@ ir_parse_features <- function(eqs, config, source) {
        has_interpolate = any(is_interpolate),
        has_stochastic = any(is_stochastic),
        has_include = !is.null(config$include),
-       initial_time_dependent = NULL)
+       initial_time_dependent = NULL,
+       safe = safe)
 }
 
 

--- a/R/odin.R
+++ b/R/odin.R
@@ -97,6 +97,10 @@
 ##'   for more information.  Defaults to the option
 ##'   \code{odin.no_check_naked_index} or \code{FALSE} otherwise.
 ##'
+##' @param safe If \code{TRUE}, then try to make some of the generated
+##'   code safer, at the cost of speed.  Only supported for the C
+##'   target.
+##'
 ##' @return A function that can generate the model
 ##'
 ##' @author Rich FitzJohn
@@ -126,7 +130,7 @@
 odin <- function(x, verbose = NULL, target = NULL, workdir = NULL,
                  validate = NULL, pretty = NULL, skip_cache = NULL,
                  compiler_warnings = NULL, no_check_unused_equations = NULL,
-                 no_check_naked_index = NULL) {
+                 no_check_naked_index = NULL, safe = NULL) {
   xx <- substitute(x)
   if (is.symbol(xx)) {
     xx <- force(x)
@@ -135,7 +139,8 @@ odin <- function(x, verbose = NULL, target = NULL, workdir = NULL,
     xx <- force(x)
   }
   odin_(xx, verbose, target, workdir, validate, pretty, skip_cache,
-        compiler_warnings, no_check_unused_equations, no_check_naked_index)
+        compiler_warnings, no_check_unused_equations, no_check_naked_index,
+        safe = safe)
 }
 
 
@@ -144,7 +149,7 @@ odin <- function(x, verbose = NULL, target = NULL, workdir = NULL,
 odin_ <- function(x, verbose = NULL, target = NULL, workdir = NULL,
                   validate = NULL, pretty = NULL, skip_cache = NULL,
                   compiler_warnings = NULL, no_check_unused_equations = NULL,
-                  no_check_naked_index = NULL) {
+                  no_check_naked_index = NULL, safe = NULL) {
   options <- odin_options(verbose = verbose,
                           target = target,
                           workdir = workdir,
@@ -153,7 +158,8 @@ odin_ <- function(x, verbose = NULL, target = NULL, workdir = NULL,
                           skip_cache = skip_cache,
                           no_check_unused_equations = no_check_unused_equations,
                           no_check_naked_index = no_check_naked_index,
-                          compiler_warnings = compiler_warnings)
+                          compiler_warnings = compiler_warnings,
+                          safe = safe)
 
   ir <- odin_parse_(x, options)
   odin_generate(ir, options)

--- a/R/odin_options.R
+++ b/R/odin_options.R
@@ -16,7 +16,7 @@ odin_options <- function(verbose = NULL, target = NULL, workdir = NULL,
                          validate = NULL, pretty = NULL, skip_cache = NULL,
                          compiler_warnings = NULL,
                          no_check_unused_equations = NULL,
-                         no_check_naked_index = NULL,
+                         no_check_naked_index = NULL, safe = NULL,
                          options = NULL) {
   default_target <-
     if (is.null(target) && !can_compile(verbose = FALSE)) "r" else "c"
@@ -29,7 +29,8 @@ odin_options <- function(verbose = NULL, target = NULL, workdir = NULL,
     skip_cache = FALSE,
     no_check_unused_equations = FALSE,
     no_check_naked_index = FALSE,
-    compiler_warnings = FALSE)
+    compiler_warnings = FALSE,
+    safe = FALSE)
   if (is.null(options)) {
     options <- list(validate = validate,
                  verbose = verbose,
@@ -39,7 +40,8 @@ odin_options <- function(verbose = NULL, target = NULL, workdir = NULL,
                  skip_cache = skip_cache,
                  no_check_unused_equations = no_check_unused_equations,
                  no_check_naked_index = no_check_naked_index,
-                 compiler_warnings = compiler_warnings)
+                 compiler_warnings = compiler_warnings,
+                 safe = safe)
   }
   stopifnot(setequal(names(defaults), names(options)))
 

--- a/inst/library.c
+++ b/inst/library.c
@@ -346,3 +346,10 @@ void interpolate_check_y(size_t nx, size_t ny, size_t i, const char *name_arg, c
     }
   }
 }
+
+double safe_rbinom(double n, double p) {
+  if (p < 0 || p > 1) {
+    Rf_error("Binomial probability is outside of [0, 1]");
+  }
+  Rf_rbinom(n, p);
+}

--- a/inst/schema.json
+++ b/inst/schema.json
@@ -200,6 +200,7 @@
                 "has_interpolate": { "type": "boolean" },
                 "has_stochastic": { "type": "boolean" },
                 "has_include": { "type": "boolean" },
+                "safe": {"type": "boolean"},
                 "initial_time_dependent": { "type": "boolean" }
             },
             "required": ["discrete", "has_array", "has_output", "has_user",

--- a/man/odin.Rd
+++ b/man/odin.Rd
@@ -5,15 +5,33 @@
 \alias{odin_}
 \title{Create an odin model}
 \usage{
-odin(x, verbose = NULL, target = NULL, workdir = NULL,
-  validate = NULL, pretty = NULL, skip_cache = NULL,
-  compiler_warnings = NULL, no_check_unused_equations = NULL,
-  no_check_naked_index = NULL)
+odin(
+  x,
+  verbose = NULL,
+  target = NULL,
+  workdir = NULL,
+  validate = NULL,
+  pretty = NULL,
+  skip_cache = NULL,
+  compiler_warnings = NULL,
+  no_check_unused_equations = NULL,
+  no_check_naked_index = NULL,
+  safe = NULL
+)
 
-odin_(x, verbose = NULL, target = NULL, workdir = NULL,
-  validate = NULL, pretty = NULL, skip_cache = NULL,
-  compiler_warnings = NULL, no_check_unused_equations = NULL,
-  no_check_naked_index = NULL)
+odin_(
+  x,
+  verbose = NULL,
+  target = NULL,
+  workdir = NULL,
+  validate = NULL,
+  pretty = NULL,
+  skip_cache = NULL,
+  compiler_warnings = NULL,
+  no_check_unused_equations = NULL,
+  no_check_naked_index = NULL,
+  safe = NULL
+)
 }
 \arguments{
 \item{x}{Either the name of a file to read, a text string (if
@@ -77,6 +95,10 @@ behaviour of this functionality changed in odin version
 change.  See \url{https://github.com/mrc-ide/odin/issues/136}
 for more information.  Defaults to the option
 \code{odin.no_check_naked_index} or \code{FALSE} otherwise.}
+
+\item{safe}{If \code{TRUE}, then try to make some of the generated
+code safer, at the cost of speed.  Only supported for the C
+target.}
 }
 \value{
 A function that can generate the model

--- a/man/odin_options.Rd
+++ b/man/odin_options.Rd
@@ -4,10 +4,19 @@
 \alias{odin_options}
 \title{Odin options}
 \usage{
-odin_options(verbose = NULL, target = NULL, workdir = NULL,
-  validate = NULL, pretty = NULL, skip_cache = NULL,
-  compiler_warnings = NULL, no_check_unused_equations = NULL,
-  no_check_naked_index = NULL, options = NULL)
+odin_options(
+  verbose = NULL,
+  target = NULL,
+  workdir = NULL,
+  validate = NULL,
+  pretty = NULL,
+  skip_cache = NULL,
+  compiler_warnings = NULL,
+  no_check_unused_equations = NULL,
+  no_check_naked_index = NULL,
+  safe = NULL,
+  options = NULL
+)
 }
 \arguments{
 \item{verbose}{Logical scalar indicating if the compilation should
@@ -67,6 +76,10 @@ behaviour of this functionality changed in odin version
 change.  See \url{https://github.com/mrc-ide/odin/issues/136}
 for more information.  Defaults to the option
 \code{odin.no_check_naked_index} or \code{FALSE} otherwise.}
+
+\item{safe}{If \code{TRUE}, then try to make some of the generated
+code safer, at the cost of speed.  Only supported for the C
+target.}
 
 \item{options}{Named list of options.  If provided, then all other
 options are ignored.}

--- a/tests/testthat/run/test-run-discrete.R
+++ b/tests/testthat/run/test-run-discrete.R
@@ -27,7 +27,8 @@ test_that("output", {
     dim(x0) <- user()
     dim(x) <- length(x0)
     dim(r) <- length(x)
-    output(total) <- sum(x)
+    total <- sum(x)
+    output(total) <- TRUE
   })
 
   x0 <- runif(10)

--- a/tests/testthat/run/test-run-stochastic.R
+++ b/tests/testthat/run/test-run-stochastic.R
@@ -129,7 +129,7 @@ test_that("round & rbinom", {
     p <- user()
     update(x) <- 0
     initial(x) <- rbinom(size, p)
-  })
+  }, safe = TRUE)
 
   mod <- gen(p = 1, size = 0.4)
   expect_equal(mod$initial(0), 0)
@@ -265,4 +265,27 @@ test_that("rexp parametrisation", {
 
   set.seed(1)
   expect_equal(y, rexp(10, 10))
+})
+
+
+test_that("out-of-bounds probabilities can raise errors", {
+  code <- quote({
+    size <- user()
+    p <- user()
+    update(x) <- 0
+    initial(x) <- rbinom(size, p)
+  })
+
+  gen <- odin(code)
+  expect_equal(gen(p = 2, size = 2)$initial(0), NaN)
+  expect_equal(gen(p = -1, size = 2)$initial(0), NaN)
+
+  ## TODO: safe should always skip cache
+  gen <- odin(code, safe = TRUE, skip_cache = TRUE)
+  expect_error(
+    gen(p = 2, size = 2)$initial(0),
+    "Binomial probability is outside of [0, 1]", fixed = TRUE)
+  expect_error(
+    gen(p = -1, size = 2)$initial(0),
+    "Binomial probability is outside of [0, 1]", fixed = TRUE)
 })

--- a/tests/testthat/run/test-run-stochastic.R
+++ b/tests/testthat/run/test-run-stochastic.R
@@ -269,6 +269,7 @@ test_that("rexp parametrisation", {
 
 
 test_that("out-of-bounds probabilities can raise errors", {
+  skip_for_target("r")
   code <- quote({
     size <- user()
     p <- user()


### PR DESCRIPTION
This does relatively little useful at the moment. It does at least cause rbinom() to error when given a probability argument that is negative or more than one.  It does not let you identify where that happened in the R code, which is what you'd really want to know, but at least we can set a breakpoint on it