### PR TITLE
mrc-1542: Allow simple operations in user defaults

### DIFF
--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -873,7 +873,8 @@ ir_parse_expr_rhs_user <- function(rhs, line, source) {
   ## runtime.  So for now, these values must be constants.  I
   ## don't want to relax that until it's clear enough how arrays
   ## get treated here.
-  if (length(deps$functions) > 0L) {
+  allowed <- c("+", "/", "-", "*", "^", "(")
+  if (length(setdiff(deps$functions, allowed)) > 0L) {
     ir_parse_error("user() call must not use functions", line, source)
   }
   if (length(deps$variables) > 0L) {

--- a/inst/schema.json
+++ b/inst/schema.json
@@ -630,10 +630,7 @@
                     "type": "object",
                     "properties": {
                         "default": {
-                            "oneOf": [
-                                {"type": "null"},
-                                {"type": "number"}
-                            ]
+                            "$ref": "#/definitions/sexpression_or_null"
                         },
                         "dim": {
                             "type": "boolean"

--- a/tests/testthat/run/test-run-basic.R
+++ b/tests/testthat/run/test-run-basic.R
@@ -145,6 +145,19 @@ test_that("user variables", {
 })
 
 
+
+test_that("simple operations in user variables are allowed", {
+  gen <- odin({
+    deriv(x) <- 1
+    initial(x) <- x0
+    x0 <- user(-1 / (2 + 3 * 4))
+  })
+
+  mod <- gen()
+  expect_equal(mod$contents()$x0, -1 / (2 + 3 * 4))
+})
+
+
 ## Tests: basic output
 ##
 ## This one is about as basic as I can see!

--- a/tests/testthat/test-parse2-general.R
+++ b/tests/testthat/test-parse2-general.R
@@ -171,6 +171,13 @@ test_that("user usage", {
 })
 
 
+test_that("user calls may use some functions", {
+  ir <- odin_parse("deriv(x) <- 1\ninitial(x) <- r\nr <- user(-2)")
+  dat <- ir_deserialise(ir)
+  expect_equal(dat$equations$r$user$default, list("-", 2))
+})
+
+
 test_that("array usage", {
   expect_error(odin_parse_(ex("y <- x\nx[1] <- 1\ndim(x) <- 10")),
                "Array 'x' used without array index", class = "odin_error")


### PR DESCRIPTION
This PR adds support for user variables to take simple arithmetic operations.  The two real cases this is useful are negative numbers:

```
x <- user(-1)
```

and fractions:

```
x <- user(2/3)
```

both of which can either be kept as expressions (which is what we do here) or computed at compile time (which I've chosen not to do)