### PR TITLE
mrc-1610: Safe behaviour when overflowing ring buffer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.0.2
+Version: 1.0.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # odin 1.0.3
 
+* Discrete models initialisation is now safe from ring buffer overflow (`mrc-1610`)
 * Support for simple calculations in user defaults (e.g., `x <- user(-1)`) - only basic arithmetic is allowed, and variables are still disabled (`mrc-1542`, reported by @MJomaba)
 
 # odin 1.0.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin 1.0.3
+
+* Support for simple calculations in user defaults (e.g., `x <- user(-1)`) - only basic arithmetic is allowed, and variables are still disabled (`mrc-1542`, reported by @MJomaba)
+
 # odin 1.0.2
 
 * Support for 2-argument round (e.g., `round(1.23, 1)` is 1.2), and enforce the same 0.5 rounding behaviour as R when used from C (`mrc-511`, #116, #179)

--- a/R/generate_c.R
+++ b/R/generate_c.R
@@ -53,6 +53,7 @@ generate_c_meta <- function(base, internal) {
     internal_t = sprintf("%s_internal", base),
     finalise = sprintf("%s_finalise", base),
     create = sprintf("%s_create", base),
+    reset = sprintf("%s_reset", base),
     contents = sprintf("%s_contents", base),
     get_internal = sprintf("%s_get_internal", base),
     set_user = sprintf("%s_set_user", base),

--- a/R/generate_c_class.R
+++ b/R/generate_c_class.R
@@ -194,6 +194,14 @@ odin_c_class_run_discrete <- function(features, env = emptyenv()) {
     check_interpolate <- NULL
   }
 
+  if (features$discrete && features$has_delay) {
+    reset <- call(".Call", quote(private$core$reset),
+                  quote(private$ptr),
+                  PACKAGE = quote(private$dll))
+  } else {
+    reset <- NULL
+  }
+
   run_args <- list(quote(y), quote(step), quote(private$core$rhs_dde),
                    quote(private$ptr), dllname = quote(private$dll),
                    parms_are_real = FALSE, ynames = FALSE,
@@ -208,7 +216,7 @@ odin_c_class_run_discrete <- function(features, env = emptyenv()) {
     quote(colnames(ret) <- private$ynames),
     quote(colnames(ret) <- NULL))
 
-  body <- drop_null(list(check_step, check_y, check_interpolate, run,
+  body <- drop_null(list(check_step, check_y, check_interpolate, reset, run,
                          cleanup, quote(ret)))
   as_function(args, r_expr_block(body), env)
 }

--- a/R/generate_r.R
+++ b/R/generate_r.R
@@ -379,6 +379,16 @@ generate_r_run <- function(dat, env, rewrite) {
     check_interpolate_t <- NULL
   }
 
+  if (dat$features$discrete && dat$features$has_delay) {
+    rings <- names_if(vlapply(dat$data$elements, function(x)
+      x$storage_type == "ring_buffer"))
+    reset <- lapply(rings, function(r)
+      as.call(list(call("$", call("[[", as.name(dat$meta$internal), r),
+                        quote(reset)))))
+  } else {
+    reset <- NULL
+  }
+
   compute_initial <-
     call("if", call("is.null", as.name(dat$meta$state)),
          r_expr_block(call("<-", as.name(dat$meta$state),
@@ -435,9 +445,8 @@ generate_r_run <- function(dat, env, rewrite) {
          call("<-", call("class", ret), "matrix")),
     call("<-", call("colnames", ret), ynames))
 
-
-  body <- drop_null(list(set_initial, check_interpolate_t, compute_initial, run,
-                         set_names, ret))
+  body <- drop_null(list(set_initial, check_interpolate_t, reset,
+                         compute_initial, run, set_names, ret))
 
   as_function(args, r_expr_block(body), env)
 }

--- a/tests/testthat/run/test-run-delay-discrete.R
+++ b/tests/testthat/run/test-run-delay-discrete.R
@@ -202,3 +202,21 @@ test_that("default (vector)", {
   expect_equal(yy$x[i + 2, ], yy$y[i, ])
   expect_equal(yy$x[1:2, ], matrix(rep(z, 2), 2, 2, TRUE))
 })
+
+
+test_that("loop around ring", {
+  gen <- odin({
+    update(x) <- x + 1
+    initial(x) <- 0
+    y <- delay(x, 4)
+    output(y) <- TRUE
+  })
+
+  mod <- gen()
+  private <- environment(mod$initialize)$private
+
+  y1 <- mod$run(c(0, 10))
+  y2 <- mod$run(c(0, DEFAULT_HISTORY_SIZE + 10))
+  y3 <- mod$run(c(0, 10))
+  expect_equal(y1, y3)
+})


### PR DESCRIPTION
This PR fixes an odd behaviour where, in a discrete time model with a delay, if the buffer has overflowed then re-use of the model object picks junk out the buffer. By resetting on run this is avoided