### PR TITLE
mrc-1620: Proof-of-concept sort

### DIFF
--- a/R/common.R
+++ b/R/common.R
@@ -98,7 +98,9 @@ FUNCTIONS <- list(
   cos = 1L,   sin = 1L,   tan = 1L,
   acos = 1L,  asin = 1L,  atan = 1L,  atan2 = 2L,
   cosh = 1L,  sinh = 1L,  tanh = 1L,
-  acosh = 1L, asinh = 1L, atanh = 1L
+  acosh = 1L, asinh = 1L, atanh = 1L,
+  ## Sorting
+  sort = 1L
 )
 
 FUNCTIONS_STOCHASTIC <- list(
@@ -133,7 +135,8 @@ FUNCTIONS_REWRITE_RF <-
   grep("_rand$", names(FUNCTIONS_STOCHASTIC), invert = TRUE, value = TRUE)
 
 FUNCTIONS_INPLACE <- list(
-  rmultinom = list(len = 3L, dest = 4L, type = "int"))
+  rmultinom = list(len = 3L, dest = 4L, type = "int"),
+  sort = list(len = 3L, dest = 3L, type = "double"))
 
 ## Here we need to do a bit of a faff because unary functions need
 ## adding.  This may get tightened up later to either use local() or

--- a/R/ir_parse_arrays.R
+++ b/R/ir_parse_arrays.R
@@ -713,7 +713,8 @@ ir_parse_arrays_check_rhs <- function(rhs, rank, int_arrays, eq, source) {
 
   ## TODO: check that the right number of indices are used when using sum?
   array_special_function <-
-    c("sum", "odin_sum", "length", "dim", "interpolate", "rmultinom")
+    c("sum", "odin_sum", "length", "dim", "interpolate",
+      names(FUNCTIONS_INPLACE))
   nms <- names(rank)
 
   check <- function(e, array_special) {

--- a/tests/testthat/run/test-run-discrete.R
+++ b/tests/testthat/run/test-run-discrete.R
@@ -175,3 +175,20 @@ test_that("complex initialisation: vector", {
   expect_equal(vv$x2, cmp * 2 + 1)
   expect_equal(mod$contents()$r, cmp * 2)
 })
+
+
+test_that("sort", {
+  gen <- odin({
+    initial(x[]) <- 0
+    update(x[]) <- x[i] + norm_rand()
+    y[] <- sort(x)
+    n <- 10
+    dim(x) <- n
+    dim(y) <- n
+    output(y) <- TRUE
+  })
+
+  mod <- gen()
+  y <- mod$transform_variables(mod$run(0:10))
+  expect_equal(t(apply(y$x, 1, sort)), y$y)
+})


### PR DESCRIPTION
Basic implementation of a `sort` function.  This is primarily interesting for discrete time models, but there's no reason that this could not be used for an ODE model too.

```r
gen <- odin({
  initial(x[]) <- 0
  update(x[]) <- x[i] + norm_rand()
  y[] <- sort(x)
  dim(x) <- 10
  dim(y) <- 10
  output(y) <- TRUE
})
```

## TODO

* Document this somewhere
* Check that both input and output vectors are doubles, or improve implementation - the `memcpy` makes this important to do
* If `order` is needed, then we need an extra bit of storage because we don't want the array sorted in place

## NOTE

Follows the same approach to `rmultinom` in that partial updates are not supported - i.e., the whole lhs is replaced by the sorted version of the rhs, so 

```
x[1,] <- sort(y[1,])
```

is not possible.

There is no checking that the lhs and the rhs are the same size and getting this wrong will cause a crash.