### PR TITLE
mrc-1621: Support for multivariate hypergeometric samples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.0.2
+Version: 1.0.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # odin 1.0.3
 
-* Support for multivariate hypergeometric function via the odin function `rmhyper()` - there is no analogue for this in base R. Like `rmultinom` this returns a vector and the inteface is subject to possible change (`mrc-1621`)
+* Support for multivariate hypergeometric function via the odin function `rmhyper()` - there is no analogue for this in base R. Like `rmultinom` this returns a vector and the interface is subject to possible change (`mrc-1621`)
 
 # odin 1.0.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin 1.0.3
+
+* Support for multivariate hypergeometric function via the odin function `rmhyper()` - there is no analogue for this in base R. Like `rmultinom` this returns a vector and the inteface is subject to possible change (`mrc-1621`)
+
 # odin 1.0.2
 
 * Support for 2-argument round (e.g., `round(1.23, 1)` is 1.2), and enforce the same 0.5 rounding behaviour as R when used from C (`mrc-511`, #116, #179)

--- a/R/common.R
+++ b/R/common.R
@@ -138,7 +138,7 @@ FUNCTIONS_REWRITE_RF <-
 
 FUNCTIONS_INPLACE <- list(
   rmultinom = list(len = 3L, dest = 4L, type = "int"),
-  rmhyper = list(len = 2L, dest = 4L, type = "int"))
+  rmhyper = list(len = 3L, dest = 4L, type = "int"))
 
 ## Here we need to do a bit of a faff because unary functions need
 ## adding.  This may get tightened up later to either use local() or

--- a/R/common.R
+++ b/R/common.R
@@ -126,14 +126,19 @@ FUNCTIONS_STOCHASTIC <- list(
   rweibull = 2L, # shape, scale
   rwilcox = 2L, # m, n
   rmultinom = 2L, # n, p
-  rsignrank = 1L # n
+  rsignrank = 1L, # n
+  ## Custom
+  rmhyper = 2L
 )
 
 FUNCTIONS_REWRITE_RF <-
-  grep("_rand$", names(FUNCTIONS_STOCHASTIC), invert = TRUE, value = TRUE)
+  setdiff(
+    grep("_rand$", names(FUNCTIONS_STOCHASTIC), invert = TRUE, value = TRUE),
+    "rmhyper")
 
 FUNCTIONS_INPLACE <- list(
-  rmultinom = list(len = 3L, dest = 4L, type = "int"))
+  rmultinom = list(len = 3L, dest = 4L, type = "int"),
+  rmhyper = list(len = 2L, dest = 4L, type = "int"))
 
 ## Here we need to do a bit of a faff because unary functions need
 ## adding.  This may get tightened up later to either use local() or

--- a/R/generate_c_compiled.R
+++ b/R/generate_c_compiled.R
@@ -728,6 +728,10 @@ generate_c_compiled_library <- function(dat, is_package) {
     }
   }
 
+  if ("rmhyper" %in% used) {
+    v <- c(v, "rmhyper", "rmhyper_i", "rmhyper_d")
+  }
+
   v <- unique(v)
   msg <- setdiff(v, names(lib$declarations))
   if (length(msg) > 0L) {

--- a/R/generate_c_equation.R
+++ b/R/generate_c_equation.R
@@ -203,9 +203,17 @@ generate_c_equation_copy <- function(eq, data_info, dat, rewrite) {
   if (data_info$rank == 0L) {
     sprintf_safe("%s = %s;", target, rewrite(eq$lhs))
   } else {
-    sprintf_safe("memcpy(%s, %s, %s * sizeof(%s));",
-                 target, rewrite(eq$lhs), rewrite(data_info$dimnames$length),
-                 data_info$storage_type)
+    len <- rewrite(data_info$dimnames$length)
+    lhs <- rewrite(eq$lhs)
+    if (data_info$storage_type == "double") {
+      sprintf_safe("memcpy(%s, %s, %s * sizeof(%s));",
+                   target, lhs, len, data_info$storage_type)
+    } else {
+      offset <- rewrite(x$offset)
+      c(sprintf_safe("for (size_t i = 0; i < %s; ++i) {", len),
+        sprintf_safe("  output[%s + i] = %s[i];", offset, lhs),
+        sprintf_safe("}", len))
+    }
   }
 }
 

--- a/R/generate_c_equation.R
+++ b/R/generate_c_equation.R
@@ -69,12 +69,12 @@ generate_c_equation_inplace_rmultinom <- function(eq, lhs, dat, rewrite) {
 generate_c_equation_inplace_rmhyper <- function(eq, lhs, data_info, dat,
                                                 rewrite) {
   len <- data_info$dimnames$length
-  src <- eq$rhs$value[[2]]
-  n <- eq$rhs$value[[3]]
+  n <- eq$rhs$value[[2]]
+  src <- eq$rhs$value[[3]]
   src_type <- dat$data$elements[[src]]$storage_type
   fn <- if (src_type == "integer") "rmhyper_i" else "rmhyper_d"
   sprintf_safe("%s(%s, %s, %s, %s);",
-               fn, rewrite(src), rewrite(len), rewrite(n), lhs)
+               fn, rewrite(n), rewrite(src), rewrite(len), lhs)
 }
 
 

--- a/R/generate_c_equation.R
+++ b/R/generate_c_equation.R
@@ -45,14 +45,7 @@ generate_c_equation_scalar <- function(eq, data_info, dat, rewrite) {
 
 generate_c_equation_inplace <- function(eq, data_info, dat, rewrite) {
   location <- data_info$location
-  if (location == "internal") {
-    lhs <- rewrite(eq$lhs)
-  } else {
-    stop("this is not possible and should be dealt with in parse")
-    offset <- dat$data[[location]]$contents[[data_info$name]]$offset
-    storage <- if (location == "variable") dat$meta$result else dat$meta$output
-    lhs <- sprintf("%s[%s]", storage, rewrite(offset))
-  }
+  lhs <- rewrite(eq$lhs)
   fn <- eq$rhs$value[[1]]
   args <- lapply(eq$rhs$value[-1], rewrite)
   switch(

--- a/R/generate_r_sexp.R
+++ b/R/generate_r_sexp.R
@@ -19,7 +19,7 @@ generate_r_sexp <- function(x, data, meta) {
       quote(rexp(1L))
     } else {
       args <- lapply(args, generate_r_sexp, data, meta)
-      if (fn %in% names(FUNCTIONS_STOCHASTIC)) {
+      if (fn %in% names(FUNCTIONS_STOCHASTIC) && fn != "rmhyper") {
         args <- c(list(1L), args)
       }
       if (fn == "rbinom") {

--- a/R/generate_r_support.R
+++ b/R/generate_r_support.R
@@ -17,6 +17,7 @@ odin_base_env <- function() {
   for (i in imports) {
     env[[i]] <- stats[[i]]
   }
+  env[["rmhyper"]] <- rmhyper
 
   env
 }

--- a/R/ir_parse_arrays.R
+++ b/R/ir_parse_arrays.R
@@ -713,7 +713,8 @@ ir_parse_arrays_check_rhs <- function(rhs, rank, int_arrays, eq, source) {
 
   ## TODO: check that the right number of indices are used when using sum?
   array_special_function <-
-    c("sum", "odin_sum", "length", "dim", "interpolate", "rmultinom")
+    c("sum", "odin_sum", "length", "dim", "interpolate",
+      names(FUNCTIONS_INPLACE))
   nms <- names(rank)
 
   check <- function(e, array_special) {

--- a/R/ir_parse_arrays.R
+++ b/R/ir_parse_arrays.R
@@ -754,7 +754,7 @@ ir_parse_arrays_check_rhs <- function(rhs, rank, int_arrays, eq, source) {
           throw("Unknown array variable %s in '%s'", x, deparse_str(e))
         }
       } else {
-        if (f_nm == "rmultinom") {
+        if (f_nm == "rmultinom" || f_nm == "rmhyper") {
           arr_idx <- 2L
         } else {
           arr_idx <- 1L

--- a/R/ir_parse_arrays.R
+++ b/R/ir_parse_arrays.R
@@ -638,7 +638,7 @@ ir_parse_arrays_find_integers <- function(eqs, variables, source) {
   ## too (treated separtately for now...)
   integer_arrays <- ir_parse_arrays_used_as_index(eqs)
   integer_inplace <- names_if(vlapply(eqs[is_inplace], function(x)
-    identical(x$rhs$value[[1]], quote(rmultinom))))
+    any(deparse(x$rhs$value[[1]]) == c("rmultinom", "rmhyper"))))
   integer_vars <- unique(c(index_vars, integer_arrays, integer_inplace))
 
   err <- vcapply(eqs[integer_inplace], function(x) x$lhs$name_data) %in%

--- a/R/support.R
+++ b/R/support.R
@@ -169,7 +169,7 @@ as_numeric <- function(x, name = deparse(substitute(x))) {
 ##   E(K_i) => n * k_i / N
 ##   Var(K_i) => n * (N - n) / (N - 1) * k_i / N * (1 - k_i / N)
 ##   Cov(K_i, K_j) => - n * (N - n) / (N - 1) * k_i / N * k_j / N
-rmhyper <- function(k, n_sample) {
+rmhyper <- function(n_sample, k) {
   N <- sum(k)
   if (n_sample > N) {
     stop(sprintf("Requesting too many elements in rmhyper (%d from %d)",

--- a/R/support.R
+++ b/R/support.R
@@ -171,6 +171,10 @@ as_numeric <- function(x, name = deparse(substitute(x))) {
 ##   Cov(K_i, K_j) => - n * (N - n) / (N - 1) * k_i / N * k_j / N
 rmhyper <- function(k, n_sample) {
   N <- sum(k)
+  if (n_sample > N) {
+    stop(sprintf("Requesting too many elements in rmhyper (%d from %d)",
+                 n_sample, N))
+  }
   m <- length(k)
   ret <- rep(0, m)
   k_other <- N - k[[1L]]

--- a/R/support.R
+++ b/R/support.R
@@ -148,3 +148,38 @@ as_numeric <- function(x, name = deparse(substitute(x))) {
     stop(sprintf("Expected numeric input for '%s'", name), call. = FALSE)
   }
 }
+
+
+## https://en.wikipedia.org/wiki/Hypergeometric_distribution
+## (section "Multivariate hypergeometric distribution")
+##
+## > the model of an urn with green and red marbles can be extended to
+## > the case where there are more than two colors of marbles. If
+## > there are K_i marbles of color i in the urn and you take n
+## > marbles at random without replacement, then the number of marbles
+## > of each color in the sample (k_1, k_2, ..., k_c) has the
+## > multivariate hypergeometric distribution. This has the same
+## > relationship to the multinomial distribution that the
+## > hypergeometric distribution has to the binomial distribution—the
+## > multinomial distribution is the "with-replacement" distribution
+## > and the multivariate hypergeometric is the "without-replacement"
+## > distribution.
+##
+## Expectations:
+##   E(K_i) => n * k_i / N
+##   Var(K_i) => n * (N - n) / (N - 1) * k_i / N * (1 - k_i / N)
+##   Cov(K_i, K_j) => - n * (N - n) / (N - 1) * k_i / N * k_j / N
+rmhyper <- function(k, n_sample) {
+  N <- sum(k)
+  m <- length(k)
+  ret <- rep(0, m)
+  k_other <- N - k[[1L]]
+  ret[[1L]] <- rhyper(1, k[[1L]], k_other, n_sample)
+  for (i in seq_len(m - 1)[-1L]) {
+    k_other <- k_other - k[[i]]
+    n_sample <- n_sample - ret[i - 1]
+    ret[[i]] <- rhyper(1, k[[i]], k_other, n_sample)
+  }
+  ret[[m]] <- n_sample - ret[[m - 1]]
+  ret
+}

--- a/inst/library.c
+++ b/inst/library.c
@@ -348,7 +348,7 @@ void interpolate_check_y(size_t nx, size_t ny, size_t i, const char *name_arg, c
 }
 
 
-void rmhyper(int *k, size_t m, size_t n_sample) {
+void rmhyper(size_t n_sample, int *k, size_t m) {
   int N = 0;
   for (size_t i = 0; i < m; ++i) {
     N += k[i];
@@ -368,15 +368,15 @@ void rmhyper(int *k, size_t m, size_t n_sample) {
 }
 
 
-void rmhyper_i(int *k, size_t m, size_t n_sample, int *ret) {
+void rmhyper_i(size_t n_sample, int *k, size_t m, int *ret) {
   memcpy(ret, k, m * sizeof(int));
-  rmhyper(ret, m, n_sample);
+  rmhyper(n_sample, ret, m);
 }
 
 
-void rmhyper_d(double *k, size_t m, size_t n_sample, int *ret) {
+void rmhyper_d(size_t n_sample, double *k, size_t m, int *ret) {
   for (size_t i = 0; i < m; ++i) {
     ret[i] = k[i];
   }
-  rmhyper(ret, m, n_sample);
+  rmhyper(n_sample, ret, m);
 }

--- a/inst/library.c
+++ b/inst/library.c
@@ -353,6 +353,10 @@ void rmhyper(int *k, size_t m, size_t n_sample) {
   for (size_t i = 0; i < m; ++i) {
     N += k[i];
   }
+  if (n_sample > N) {
+    Rf_error("Requesting too many elements in rmhyper (%d from %d)",
+             n_sample, N);
+  }
   int k_other = N - k[0];
   k[0] = Rf_rhyper(k[0], k_other, n_sample);
   for (size_t i = 1; i < m - 1; ++i) {

--- a/inst/library.c
+++ b/inst/library.c
@@ -346,3 +346,33 @@ void interpolate_check_y(size_t nx, size_t ny, size_t i, const char *name_arg, c
     }
   }
 }
+
+
+void rmhyper(int *k, size_t m, size_t n_sample) {
+  int N = 0;
+  for (size_t i = 0; i < m; ++i) {
+    N += k[i];
+  }
+  int k_other = N - k[0];
+  k[0] = Rf_rhyper(k[0], k_other, n_sample);
+  for (size_t i = 1; i < m - 1; ++i) {
+    k_other -= k[i];
+    n_sample -= k[i - 1];
+    k[i] = Rf_rhyper(k[i], k_other, n_sample);
+  }
+  k[m - 1] = n_sample - k[m - 2];
+}
+
+
+void rmhyper_i(int *k, size_t m, size_t n_sample, int *ret) {
+  memcpy(ret, k, m * sizeof(int));
+  rmhyper(ret, m, n_sample);
+}
+
+
+void rmhyper_d(double *k, size_t m, size_t n_sample, int *ret) {
+  for (size_t i = 0; i < m; ++i) {
+    ret[i] = k[i];
+  }
+  rmhyper(ret, m, n_sample);
+}

--- a/tests/testthat/run/test-run-library.R
+++ b/tests/testthat/run/test-run-library.R
@@ -151,6 +151,7 @@ test_that("multivariate hypergeometric", {
     ## incompatible.
     tmp[] <- rmhyper(x0, n)
     dim(tmp) <- nk
+    output(tmp) <- TRUE
 
     initial(x[]) <- 0
     update(x[]) <- tmp[i]
@@ -166,5 +167,7 @@ test_that("multivariate hypergeometric", {
   set.seed(1)
   cmp <- t(replicate(10, rmhyper(k, n)))
 
-  expect_equal(mod$transform_variables(res)$x[-1L, ], cmp)
+  yy <- mod$transform_variables(res)
+  expect_equal(yy$x[-1L, ], cmp)
+  expect_equal(yy$tmp[-11L, ], yy$x[-1L, ])
 })

--- a/tests/testthat/run/test-run-library.R
+++ b/tests/testthat/run/test-run-library.R
@@ -136,3 +136,35 @@ test_that("2-arg round", {
   expect_equal(yy1[, "y"], round(tt, 1))
   expect_equal(yy2[, "y"], round(tt, 2))
 })
+
+
+test_that("multivariate hypergeometric", {
+  gen <- odin({
+    x0[] <- user()
+    dim(x0) <- user()
+    n <- user()
+
+    nk <- length(x0)
+
+    ## We can't accept output from rmhyper (or e.g., rmultinom)
+    ## directly into the state vector because the pointer types are
+    ## incompatible.
+    tmp[] <- rmhyper(x0, n)
+    dim(tmp) <- nk
+
+    initial(x[]) <- 0
+    update(x[]) <- tmp[i]
+    dim(x) <- nk
+  })
+
+  k <- c(6, 10, 15, 3, 0, 4)
+  n <- 20
+  mod <- gen(x0 = k, n = n)
+
+  set.seed(1)
+  res <- mod$run(0:10)
+  set.seed(1)
+  cmp <- t(replicate(10, rmhyper(k, n)))
+
+  expect_equal(mod$transform_variables(res)$x[-1L, ], cmp)
+})

--- a/tests/testthat/run/test-run-library.R
+++ b/tests/testthat/run/test-run-library.R
@@ -171,3 +171,26 @@ test_that("multivariate hypergeometric", {
   expect_equal(yy$x[-1L, ], cmp)
   expect_equal(yy$tmp[-11L, ], yy$x[-1L, ])
 })
+
+
+test_that("Throw an error if requesting more elements than possible", {
+  gen <- odin({
+    b[] <- user()
+    n <- user()
+
+    initial(x[]) <- 0
+    update(x[]) <- x[i] + b[i]
+    y[] <- rmhyper(x, n)
+    output(y) <- TRUE
+
+    dim(x) <- 3
+    dim(b) <- 3
+    dim(y) <- 3
+  })
+  b <- c(10, 15, 9)
+  n <- 10
+  mod <- gen(b = b, n = n)
+  expect_error(mod$run(step = 2),
+               "Requesting too many elements in rmhyper (10 from 0)",
+               fixed = TRUE)
+})

--- a/tests/testthat/run/test-run-library.R
+++ b/tests/testthat/run/test-run-library.R
@@ -149,7 +149,7 @@ test_that("multivariate hypergeometric", {
     ## We can't accept output from rmhyper (or e.g., rmultinom)
     ## directly into the state vector because the pointer types are
     ## incompatible.
-    tmp[] <- rmhyper(x0, n)
+    tmp[] <- rmhyper(n, x0)
     dim(tmp) <- nk
     output(tmp) <- TRUE
 
@@ -165,7 +165,7 @@ test_that("multivariate hypergeometric", {
   set.seed(1)
   res <- mod$run(0:10)
   set.seed(1)
-  cmp <- t(replicate(10, rmhyper(k, n)))
+  cmp <- t(replicate(10, rmhyper(n, k)))
 
   yy <- mod$transform_variables(res)
   expect_equal(yy$x[-1L, ], cmp)
@@ -180,7 +180,7 @@ test_that("Throw an error if requesting more elements than possible", {
 
     initial(x[]) <- 0
     update(x[]) <- x[i] + b[i]
-    y[] <- rmhyper(x, n)
+    y[] <- rmhyper(n, x)
     output(y) <- TRUE
 
     dim(x) <- 3

--- a/tests/testthat/test-parse-inplace.R
+++ b/tests/testthat/test-parse-inplace.R
@@ -51,13 +51,13 @@ test_that("rmultinom is integer", {
 })
 
 
-test_that("rmultinom is integer", {
+test_that("rmhyper is integer", {
   ir <- odin_parse({
     x0[] <- user()
     dim(x0) <- user()
     n <- user()
     nk <- length(x0)
-    tmp[] <- rmhyper(x0, n)
+    tmp[] <- rmhyper(n, x0)
     dim(tmp) <- nk
     initial(x[]) <- 0
     update(x[]) <- tmp[i]

--- a/tests/testthat/test-parse-inplace.R
+++ b/tests/testthat/test-parse-inplace.R
@@ -51,6 +51,24 @@ test_that("rmultinom is integer", {
 })
 
 
+test_that("rmultinom is integer", {
+  ir <- odin_parse({
+    x0[] <- user()
+    dim(x0) <- user()
+    n <- user()
+    nk <- length(x0)
+    tmp[] <- rmhyper(x0, n)
+    dim(tmp) <- nk
+    initial(x[]) <- 0
+    update(x[]) <- tmp[i]
+    dim(x) <- nk
+  })
+  dat <- ir_deserialise(ir)
+  expect_equal(dat$data$elements$tmp$storage_type, "int")
+  expect_equal(dat$data$elements$tmp$rank, 1)
+})
+
+
 test_that("rmultinom argument validation", {
   expect_error(odin_parse({
     update(x) <- 1

--- a/tests/testthat/test-support.R
+++ b/tests/testthat/test-support.R
@@ -85,6 +85,14 @@ test_that("multivariate hypergeometric distribution", {
 })
 
 
+test_that("prevent oversampling in rmhyper", {
+  expect_error(
+    rmhyper(0:5, 100),
+    "Requesting too many elements in rmhyper (100 from 15)",
+    fixed = TRUE)
+})
+
+
 test_that("multivariate hypergeometric distribution (C)", {
   skip_on_cran()
 
@@ -131,4 +139,9 @@ test_that("multivariate hypergeometric distribution (C)", {
   expect_equal(b1, a)
   expect_equal(b2, a)
   expect_identical(b1, b2)
+
+  expect_error(
+    rmhyper_c(as.integer(k), 100),
+    "Requesting too many elements in rmhyper (100 from 38)",
+    fixed = TRUE)
 })

--- a/tests/testthat/test-support.R
+++ b/tests/testthat/test-support.R
@@ -61,3 +61,25 @@ test_that("as_numeric errors appropriately", {
   expect_error(as_numeric(TRUE), "Expected numeric input for 'TRUE'")
   expect_error(as_numeric("x"), "Expected numeric input for")
 })
+
+
+test_that("multivariate hypergeometric distribution", {
+  k <- c(6, 10, 15, 3, 0, 4)
+  n <- 20
+  N <- sum(k)
+
+  set.seed(1)
+  res <- t(replicate(5000, rmhyper(k, n)))
+
+  ## Population is preserved
+  expect_true(all(rowSums(res) == n))
+
+  ## Mean
+  expect_equal(colMeans(res), n * k / N, tolerance = 0.05)
+
+  ## Variance and covariance
+  expected <- outer(k, k, function(ki, kj)
+    - n * (N - n) / (N - 1) * ki / N * kj / N)
+  diag(expected) <- n * (N - n) / (N - 1) * k / N * (1 - k / N)
+  expect_equal(cov(res), expected, tolerance = 0.05)
+})


### PR DESCRIPTION
This PR adds support for `rmhyper`, a multivariate version of `rhyper`.  Takes as arguments a vector `k` of "balls" in each of a number of categories and `n` the number of "balls" to sample without replacement.

~## TODO:~

* ~Document this somewhere (#187)~
* ~Add error if `n` is greater than `sum(k)`~
* ~I've added unreachable code in `generate_c_equation_inplace` that needs to become a check in the parse phase~

## NOTE

Follows the same approach to `rmultinom` in that partial updates are not supported - i.e., the whole lhs is replaced by the sorted version of the rhs, so 

```
x[1,] <- rmhyper(k[1,], n)
```

is not possible.

There is no checking that the lhs and the rhs are the same size and getting this wrong will cause a crash.
