### PR TITLE
i196: initial arrays

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.0.5
+Version: 1.0.6
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin 1.0.6
+
+* Fixed bug in code generation for initial conditions involving sums of matrices (#196)
+
 # odin 1.0.3
 
 * Support for multivariate hypergeometric function via the odin function `rmhyper()` - there is no analogue for this in base R. Like `rmultinom` this returns a vector and the interface is subject to possible change (`mrc-1621`)

--- a/R/generate_c_sexp.R
+++ b/R/generate_c_sexp.R
@@ -28,6 +28,7 @@ generate_c_sexp <- function(x, data, meta, supported) {
       ret <- generate_c_sexp(data$elements[[args[[1L]]]]$dimnames$length,
                              data, meta, supported)
     } else if (fn == "dim") {
+      args[[1]] <- sub(sprintf("^%s->", INTERNAL), "", args[[1]])
       dim <- data$elements[[args[[1L]]]]$dimnames$dim[[args[[2]]]]
       ret <- generate_c_sexp(dim, data, meta, supported)
     } else if (fn %in% c("norm_rand", "unif_rand", "exp_rand")) {
@@ -77,7 +78,7 @@ generate_c_sexp <- function(x, data, meta, supported) {
 
 generate_c_sexp_sum <- function(args, data, meta, supported) {
   target <- generate_c_sexp(args[[1]], data, meta, supported)
-  data_info <- data$elements[[args[[1]]]]
+  data_info <- data$elements[[sub(sprintf("^%s->", INTERNAL), "", args[[1]])]]
   type <- data_info$storage_type
   if (length(args) == 1L) {
     fn <- if (type == "int") "odin_isum1" else "odin_sum1"

--- a/tests/testthat/run/test-run-general.R
+++ b/tests/testthat/run/test-run-general.R
@@ -928,6 +928,18 @@ test_that("sum for a 4d array", {
   expect_equal(dat$m24, apply(a, c(2, 4), sum))
 })
 
+test_that("sum initial condition from initial condition", {
+  gen <- odin({
+    update(a[, ]) <- 1
+    update(b) <- 1
+    initial(a[, ]) <- 1
+    initial(b) <- n
+    n <- sum(a[1, ])
+    dim(a) <- c(10, 10)
+  })
+  expect_equal(gen()$initial(0), c(10, rep(1, 100)))
+})
+
 test_that("self output for scalar", {
   gen <- odin({
     initial(a) <- 1

--- a/tests/testthat/run/test-run-general.R
+++ b/tests/testthat/run/test-run-general.R
@@ -940,6 +940,18 @@ test_that("sum initial condition from initial condition", {
   expect_equal(gen()$initial(0), c(10, rep(1, 100)))
 })
 
+test_that("another initial condition failure", {
+  gen <- odin({
+    deriv(a[]) <- 1
+    deriv(b) <- 1
+    initial(a[]) <- 1
+    initial(b) <- n
+    n <- sum(a)
+    dim(a) <- 10
+  })
+  expect_equal(gen()$initial(0), c(10, rep(1, 10)))
+})
+
 test_that("self output for scalar", {
   gen <- odin({
     initial(a) <- 1


### PR DESCRIPTION
This PR is an ugly fix to an ugly problem. When working with arrays in initial conditions, the `initial->` added by `ir_substitute` needs to be removed.

I thought that this was related to #193 but it does not appear to be.

Fixes #196 