### PR TITLE
Add basic as.integer support (#199)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.0.6
+Version: 1.0.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin 1.0.7
+
+* Support for `as.integer()` to cast to integer for use within array expressions (#200)
+
 # odin 1.0.6
 
 * Fixed bug in code generation for initial conditions involving sums of matrices (#196)

--- a/R/common.R
+++ b/R/common.R
@@ -27,7 +27,7 @@ INTERNAL <- "internal"
 RESERVED <- c(INDEX, TIME, STEP, STATE, DSTATEDT, STATE_NEXT, USER,
               SPECIAL_LHS, "delay", "dde", INTERNAL)
 RESERVED_PREFIX <- c(SPECIAL_LHS, "odin", "offset", "delay", "interpolate")
-VALID_ARRAY <- c("-", "+", ":", "(", "length", "dim", "[")
+VALID_ARRAY <- c("-", "+", ":", "(", "length", "dim", "[", "as.integer")
 INTERPOLATION_TYPES <- c("constant", "linear", "spline")
 SPECIAL_DATA_TYPES <- c("void", "ring_buffer")
 
@@ -94,6 +94,7 @@ FUNCTIONS <- list(
   trunc = 1L,
   floor = 1L,
   ceil = 1L,
+  as.integer = 1L,
   ## Big pile of trig:
   cos = 1L,   sin = 1L,   tan = 1L,
   acos = 1L,  asin = 1L,  atan = 1L,  atan2 = 2L,

--- a/R/generate_c_sexp.R
+++ b/R/generate_c_sexp.R
@@ -43,6 +43,8 @@ generate_c_sexp <- function(x, data, meta, supported) {
       ret <- c_fold_call(paste0("f", fn), values)
     } else if (fn == "sum" || fn == "odin_sum") {
       ret <- generate_c_sexp_sum(args, data, meta, supported)
+    } else if (fn == "as.integer") {
+      ret <- sprintf("(int) (%s)", values[[1L]])
     } else {
       if (fn == "rbinom") {
         ## This is a little extreme but is useful in at least some

--- a/tests/testthat/run/test-run-general.R
+++ b/tests/testthat/run/test-run-general.R
@@ -1291,3 +1291,34 @@ test_that("sum over integer", {
   expect_equal(mod$update(0, mod$initial(0)),
                rep(sum(idx), 15))
 })
+
+
+test_that("force integer on use", {
+  gen <- odin({
+    vec[] <- i
+    dim(vec) <- 2
+    idx <- if (t > 5) 2 else 1
+    deriv(x) <- vec[as.integer(idx)]
+    initial(x) <- 0
+  })
+
+  mod <- gen()
+  t <- seq(0, 10, length.out = 101)
+  y <- mod$run(t, atol = 1e-9, rtol = 1e-9)
+  expect_equal(y[, 2], ifelse(t <= 5, t, 2 * t - 5))
+})
+
+
+test_that("force integer on a numeric vector truncates", {
+  gen <- odin({
+    vec[] <- i
+    dim(vec) <- 10
+    idx <- user()
+    initial(x) <- vec[as.integer(idx)]
+    deriv(x) <- 0
+  })
+
+  expect_equal(gen(idx = 1.5)$initial(), 1)
+  expect_equal(gen(idx = 3 - 1e-8)$initial(), 2)
+  expect_equal(gen(idx = 3 + 1e-8)$initial(), 3)
+})

--- a/vignettes/functions.Rmd
+++ b/vignettes/functions.Rmd
@@ -116,6 +116,22 @@ for (i in 1:dim(ay, 1)) {
 }
 ```
 
+Due to constraints with using C, few things can be used as an index; in particular the following will not work:
+
+```r
+idx <- if (t > 5) 2 else 1
+x <- vec[idx]
+```
+
+(or where `idx` is some general odin variable as the result of a different assignment). You must use `as.integer` to cast this to integer immediately before indexing:
+
+```r
+idx <- if (t > 5) 2 else 1
+x <- vec[as.integer(idx)]
+```
+
+This will *truncate* the value (same behaviour as `truncate`) so be warned if passing in things that may be approximately integer - you may want to use `as.integer(round(x))` in that case.
+
 The interpolation functions are described in more detail in the
 [main package vignette](odin.html)
 


### PR DESCRIPTION
Support for `as.integer`, in order to get integer values for use with array indexing.

Fixes #199 
