### PR TITLE
More flexible user-supplied functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin 1.1.2
+
+* Support for `config(include)` has been expanded, working for R models and designed to be extensible for other targets (mrc-2016)
+
 # odin 1.1.0
 
 * The basic infrastructure has been overhauled, which will make some alternative compilation targets easier to support. We now use `pkgbuild` for the compilation which should ease debugging, and odin code compiled into packages will no longer issue a slew of warnings (and cooperate with automatic routine registration). This refactor has caused a few minor breaking changes:

--- a/R/generate_c.R
+++ b/R/generate_c.R
@@ -34,7 +34,7 @@ generate_c_code <- function(dat, options, package) {
   }
 
   rewrite <- function(x) {
-    generate_c_sexp(x, dat$data, dat$meta, names(dat$config$include))
+    generate_c_sexp(x, dat$data, dat$meta, dat$config$include$names)
   }
 
   eqs <- generate_c_equations(dat, rewrite)

--- a/R/generate_c.R
+++ b/R/generate_c.R
@@ -44,7 +44,7 @@ generate_c_code <- function(dat, options, package) {
 
   is_package <- !is.null(package)
   lib <- generate_c_compiled_library(dat, is_package)
-  include <- generate_c_compiled_include(dat, is_package)
+  include <- generate_c_compiled_include(dat)
 
   if (dat$features$has_delay && dat$features$discrete) {
     ring <- generate_c_support_ring(is_package)
@@ -65,12 +65,12 @@ generate_c_code <- function(dat, options, package) {
               struct,
               core$declaration,
               lib$declaration,
-              include$declaration)
+              unname(include$declarations))
     defn <- c(core$definition,
               lib$definition,
               ring$definitions,
               interpolate$definitions,
-              include$definition)
+              unname(include$definitions))
     list(code = c(decl, defn), core = core$name)
   } else {
     list(headers = headers,

--- a/R/generate_c_compiled.R
+++ b/R/generate_c_compiled.R
@@ -764,13 +764,20 @@ generate_c_compiled_library <- function(dat, is_package) {
 }
 
 
-generate_c_compiled_include <- function(dat, is_package) {
+generate_c_compiled_include <- function(dat) {
   include <- dat$config$include$data
 
-  if (is_package) {
-    include
-  } else {
-    list(declaration = c_flatten_eqs(lapply(include, "[[", "declaration")),
-         definition = c_flatten_eqs(lapply(include, "[[", "definition")))
+  if (length(include) == 0) {
+    return(NULL)
   }
+
+  ## When this has been through the serialise/deserialise step it has
+  ## lost some structure, so we return named vectors
+  ret <- lapply(include, function(x) {
+    nms <- list_to_character(x$names)
+    list(names = nms,
+         declarations = set_names(list_to_character(x$declarations), nms),
+         definitions = set_names(list_to_character(x$definitions), nms))
+  })
+  unlist(ret, FALSE)
 }

--- a/R/generate_c_compiled.R
+++ b/R/generate_c_compiled.R
@@ -765,7 +765,8 @@ generate_c_compiled_library <- function(dat, is_package) {
 
 
 generate_c_compiled_include <- function(dat, is_package) {
-  include <- dat$config$include
+  include <- dat$config$include$data
+
   if (is_package) {
     include
   } else {

--- a/R/generate_r.R
+++ b/R/generate_r.R
@@ -27,6 +27,8 @@ generate_r <- function(dat, options) {
   ## Then start putting together the initial conditions
   env <- new.env(parent = odin_base_env())
 
+  generate_r_include(dat, env)
+
   ## Support functions will come in this way:
   if (dat$features$has_user) {
     env[[dat$meta$support$get_user_double]] <- support_get_user_double
@@ -453,4 +455,15 @@ generate_r_dim <- function(data_info, rewrite) {
   } else {
     as.call(c(list(quote(c)), lapply(data_info$dimnames$dim, rewrite)))
   }
+}
+
+
+generate_r_include <- function(dat, env) {
+  ## TODO: will this work with >1 include?
+  include <- dat$config$include$data
+  src <- list_to_character(include$source)
+  tmp <- tempfile()
+  on.exit(unlink(tmp))
+  writeLines(src, tmp)
+  sys.source(tmp, env)
 }

--- a/R/generate_r.R
+++ b/R/generate_r.R
@@ -459,11 +459,12 @@ generate_r_dim <- function(data_info, rewrite) {
 
 
 generate_r_include <- function(dat, env) {
-  ## TODO: will this work with >1 include?
   include <- dat$config$include$data
-  src <- list_to_character(include$source)
-  tmp <- tempfile()
-  on.exit(unlink(tmp))
-  writeLines(src, tmp)
-  sys.source(tmp, env)
+  if (length(include) > 0) {
+    src <- unlist(lapply(include, function(x) list_to_character(x$source)))
+    tmp <- tempfile()
+    on.exit(unlink(tmp))
+    writeLines(src, tmp)
+    sys.source(tmp, env)
+  }
 }

--- a/R/ir_deserialise.R
+++ b/R/ir_deserialise.R
@@ -42,8 +42,6 @@ ir_deserialise <- function(ir) {
   names(dat$equations) <- vcapply(dat$equations, "[[", "name")
   names(dat$user) <- vcapply(dat$user, "[[", "name")
 
-  names(dat$config$include) <- vcapply(dat$config$include, "[[", "name")
-
   dat$interpolate <- lapply(dat$interpolate, list_to_character)
   dat$equations <- lapply(dat$equations, ir_deserialise_equation)
   dat$ir <- ir

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -9,7 +9,7 @@ ir_parse <- function(x, options, type = NULL) {
   source <- dat$source
 
   ## Data elements:
-  config <- ir_parse_config(eqs, base, root, source, options$parse_include)
+  config <- ir_parse_config(eqs, base, root, source, options$read_include)
   features <- ir_parse_features(eqs, config, source)
 
   variables <- ir_parse_find_variables(eqs, features$discrete, source)

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -16,7 +16,7 @@ ir_parse <- function(x, options, type = NULL) {
 
   eqs <- lapply(eqs, ir_parse_rewrite_initial, variables)
 
-  eqs <- ir_parse_arrays(eqs, variables, source)
+  eqs <- ir_parse_arrays(eqs, variables, config$include, source)
 
   packing <- ir_parse_packing(eqs, variables, source)
   eqs <- c(eqs, packing$offsets)

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -9,14 +9,14 @@ ir_parse <- function(x, options, type = NULL) {
   source <- dat$source
 
   ## Data elements:
-  config <- ir_parse_config(eqs, base, root, source)
+  config <- ir_parse_config(eqs, base, root, source, options$parse_include)
   features <- ir_parse_features(eqs, config, source)
 
   variables <- ir_parse_find_variables(eqs, features$discrete, source)
 
   eqs <- lapply(eqs, ir_parse_rewrite_initial, variables)
 
-  eqs <- ir_parse_arrays(eqs, variables, config$include, source)
+  eqs <- ir_parse_arrays(eqs, variables, config$include$names, source)
 
   packing <- ir_parse_packing(eqs, variables, source)
   eqs <- c(eqs, packing$offsets)
@@ -74,7 +74,7 @@ ir_parse <- function(x, options, type = NULL) {
   equations <- ir_parse_equations(eqs)
 
   ## TODO: it's a bit unclear where this best belongs
-  ir_parse_check_functions(eqs, features$discrete, config$include, source)
+  ir_parse_check_functions(eqs, features$discrete, config$include$names, source)
 
   ret <- list(version = .odin$version,
               config = config,
@@ -1129,7 +1129,7 @@ ir_parse_check_functions <- function(eqs, discrete, include, source) {
                names(FUNCTIONS_UNARY),
                names(FUNCTIONS_RENAME),
                "odin_sum",
-               names(include),
+               include,
                if (discrete) names(FUNCTIONS_STOCHASTIC))
 
   err <- setdiff(all_used_functions, allowed)

--- a/R/ir_parse_arrays.R
+++ b/R/ir_parse_arrays.R
@@ -719,7 +719,7 @@ ir_parse_arrays_check_rhs <- function(rhs, rank, int_arrays, include, eq,
   ## TODO: check that the right number of indices are used when using sum?
   array_special_function <-
     c("sum", "odin_sum", "length", "dim", "interpolate",
-      names(FUNCTIONS_INPLACE), names(include))
+      names(FUNCTIONS_INPLACE), include)
   nms <- names(rank)
 
   check <- function(e, array_special) {
@@ -758,7 +758,7 @@ ir_parse_arrays_check_rhs <- function(rhs, rank, int_arrays, include, eq,
         } else {
           throw("Unknown array variable %s in '%s'", x, deparse_str(e))
         }
-      } else if (f_nm %in% names(include)) {
+      } else if (f_nm %in% include) {
         ## Suspends all further checking on user-supplied functions
       } else {
         if (f_nm == "rmultinom" || f_nm == "rmhyper") {

--- a/R/ir_parse_arrays.R
+++ b/R/ir_parse_arrays.R
@@ -27,7 +27,7 @@
 ##
 ## The dim() calls get written out as a new group of data elements;
 ## we'll sort that out here too.
-ir_parse_arrays <- function(eqs, variables, source) {
+ir_parse_arrays <- function(eqs, variables, include, source) {
   ir_parse_arrays_check_indices(eqs, source)
   eqs <- ir_parse_arrays_find_integers(eqs, variables, source)
 
@@ -71,7 +71,7 @@ ir_parse_arrays <- function(eqs, variables, source) {
     eqs[[eq$name]]$array <- eqs[[eq$lhs$name_data]]$array
   }
 
-  ir_parse_arrays_check_usage2(eqs, source)
+  ir_parse_arrays_check_usage2(eqs, include, source)
 
   eqs
 }
@@ -144,7 +144,7 @@ ir_parse_arrays_check_usage <- function(eqs, source) {
 }
 
 
-ir_parse_arrays_check_usage2 <- function(eqs, source) {
+ir_parse_arrays_check_usage2 <- function(eqs, include, source) {
   ## TODO: this feels really icky, but at least gets there.  What
   ## would be nicer in the longer term perhaps is something that flags
   ## the "canonical" version of a piece of data amongst equations.
@@ -164,18 +164,22 @@ ir_parse_arrays_check_usage2 <- function(eqs, source) {
 
   for (eq in eqs) {
     if (eq$type == "expression_scalar" || eq$type == "expression_inplace") {
-      ir_parse_arrays_check_rhs(eq$rhs$value, rank, int_arrays, eq, source)
+      ir_parse_arrays_check_rhs(eq$rhs$value, rank, int_arrays, include,
+                                eq, source)
     } else if (eq$type == "expression_array") {
       for (el in eq$rhs) {
-        ir_parse_arrays_check_rhs(el$value, rank, int_arrays, eq, source)
+        ir_parse_arrays_check_rhs(el$value, rank, int_arrays, include,
+                                  eq, source)
       }
     } else if (eq$type == "delay") {
-      ir_parse_arrays_check_rhs(eq$rhs$value, rank, int_arrays, eq, source)
-      ir_parse_arrays_check_rhs(eq$delay$default, rank, int_arrays, eq, source)
+      ir_parse_arrays_check_rhs(eq$rhs$value, rank, int_arrays, include,
+                                eq, source)
+      ir_parse_arrays_check_rhs(eq$delay$default, rank, int_arrays, include,
+                                eq, source)
     } else {
       ## TODO: not sure what comes through here, or if this is correct
       ## at all.
-      ir_parse_arrays_check_rhs(eq, rank, int_arrays, source)
+      ir_parse_arrays_check_rhs(eq, rank, int_arrays, include, eq, source)
     }
   }
 }
@@ -706,7 +710,8 @@ ir_parse_arrays_used_as_index <- function(eqs) {
 }
 
 
-ir_parse_arrays_check_rhs <- function(rhs, rank, int_arrays, eq, source) {
+ir_parse_arrays_check_rhs <- function(rhs, rank, int_arrays, include, eq,
+                                      source) {
   throw <- function(...) {
     ir_parse_error(sprintf(...), eq$source, source)
   }
@@ -714,7 +719,7 @@ ir_parse_arrays_check_rhs <- function(rhs, rank, int_arrays, eq, source) {
   ## TODO: check that the right number of indices are used when using sum?
   array_special_function <-
     c("sum", "odin_sum", "length", "dim", "interpolate",
-      names(FUNCTIONS_INPLACE))
+      names(FUNCTIONS_INPLACE), names(include))
   nms <- names(rank)
 
   check <- function(e, array_special) {
@@ -753,6 +758,8 @@ ir_parse_arrays_check_rhs <- function(rhs, rank, int_arrays, eq, source) {
         } else {
           throw("Unknown array variable %s in '%s'", x, deparse_str(e))
         }
+      } else if (f_nm %in% names(include)) {
+        ## Suspends all further checking on user-supplied functions
       } else {
         if (f_nm == "rmultinom" || f_nm == "rmhyper") {
           arr_idx <- 2L

--- a/R/ir_parse_config.R
+++ b/R/ir_parse_config.R
@@ -6,7 +6,8 @@ ir_parse_config <- function(eqs, base_default, root, source, parse_include) {
   nms <- vcapply(config, function(x) x$lhs$name_data)
 
   base <- ir_parse_config_base(config[nms == "base"], base_default, source)
-  include <- parse_include(config[nms == "include"], root, source)
+  include <- ir_parse_config_include(config[nms == "include"], root, source,
+                                     parse_include)
 
   list(base = base, include = include)
 }
@@ -30,6 +31,14 @@ ir_parse_config_base <- function(config, base_default, source) {
   }
 
   base
+}
+
+
+ir_parse_config_include <- function(include, root, source, parse_include) {
+  if (length(include) == 0) {
+    return(NULL)
+  }
+  parse_include(include, root, source)
 }
 
 

--- a/R/ir_parse_config.R
+++ b/R/ir_parse_config.R
@@ -1,4 +1,4 @@
-ir_parse_config <- function(eqs, base_default, root, source) {
+ir_parse_config <- function(eqs, base_default, root, source, parse_include) {
   i <- vcapply(eqs, "[[", "type") == "config"
 
   config <- lapply(unname(eqs[i]), ir_parse_config1, source)
@@ -6,7 +6,7 @@ ir_parse_config <- function(eqs, base_default, root, source) {
   nms <- vcapply(config, function(x) x$lhs$name_data)
 
   base <- ir_parse_config_base(config[nms == "base"], base_default, source)
-  include <- ir_parse_config_include(config[nms == "include"], root, source)
+  include <- parse_include(config[nms == "include"], root, source)
 
   list(base = base, include = include)
 }
@@ -63,12 +63,14 @@ ir_parse_config_include <- function(config, root, source) {
 
   declarations <- strsplit(res$declarations, "\n")
   definitions <- strsplit(res$definitions, "\n")
-  ret <- lapply(names(res$declarations), function(x)
+  data <- lapply(names(res$declarations), function(x)
     list(name = x,
          declaration = declarations[[x]],
          definition = definitions[[x]]))
-  names(ret) <- names(res$declarations)
-  ret
+  names(data) <- names(res$declarations)
+
+  list(names = names(data),
+       data = data)
 }
 
 

--- a/R/ir_parse_config.R
+++ b/R/ir_parse_config.R
@@ -52,7 +52,6 @@ ir_parse_config_include <- function(include, root, source, read_include) {
       x$source, source)
   }
 
-  ## TODO: do we want to inject the filename in here?
   res <- lapply(filename_full, function(path)
     withCallingHandlers(
       read_include(path),

--- a/R/ir_parse_config.R
+++ b/R/ir_parse_config.R
@@ -1,4 +1,4 @@
-ir_parse_config <- function(eqs, base_default, root, source, parse_include) {
+ir_parse_config <- function(eqs, base_default, root, source, read_include) {
   i <- vcapply(eqs, "[[", "type") == "config"
 
   config <- lapply(unname(eqs[i]), ir_parse_config1, source)
@@ -7,7 +7,7 @@ ir_parse_config <- function(eqs, base_default, root, source, parse_include) {
 
   base <- ir_parse_config_base(config[nms == "base"], base_default, source)
   include <- ir_parse_config_include(config[nms == "include"], root, source,
-                                     parse_include)
+                                     read_include)
 
   list(base = base, include = include)
 }
@@ -34,96 +34,41 @@ ir_parse_config_base <- function(config, base_default, source) {
 }
 
 
-ir_parse_config_include <- function(include, root, source, parse_include) {
+ir_parse_config_include <- function(include, root, source, read_include) {
   if (length(include) == 0) {
     return(NULL)
   }
-  parse_include(include, root, source)
-}
 
-
-ir_parse_config_include_unsupported <- function(target) {
-  force(target)
-  function(...) {
-    stop(sprintf("'config(include)' is not supported for target '%s'", target))
-  }
-}
-
-
-ir_parse_config_include_r <- function(config, root, source) {
-  if (length(config) == 0L) {
-    return(NULL)
+  ## First check that the paths exist:
+  filename <- vcapply(include, function(x) x$rhs$value)
+  filename_full <- file.path(root, filename)
+  msg <- !file.exists(filename_full)
+  if (any(msg)) {
+    ## Only throw here on the first, for simplicity
+    x <- include[msg][[1]]
+    ir_parse_error(
+      sprintf("Could not find file '%s' (relative to root '%s')",
+              x$rhs$value, root),
+      x$source, source)
   }
 
-  read1 <- function(x) {
-    filename <- file.path(root, x$rhs$value)
-    if (!file.exists(filename)) {
-      ir_parse_error(
-        sprintf("Could not find file '%s' (relative to root '%s')",
-                x$rhs$value, root),
-        x$source, source)
-    }
-    tryCatch(
-      read_user_r(filename),
-      error = function(e)
-        ir_parse_error(paste("Could not read include file:", e$message),
-                       x$source, source))
-  }
+  ## TODO: do we want to inject the filename in here?
+  res <- lapply(filename_full, function(path)
+    withCallingHandlers(
+      read_include(path),
+      error = function(e) message(sprintf("While reading '%s'", path))))
 
-  res <- lapply(config, read1)
-
-  nms <- unlist(lapply(res, names))
+  nms <- unlist(lapply(res, "[[", "names"))
   dups <- unique(nms[duplicated(nms)])
   if (length(dups) > 0L) {
+    lines <- vnapply(include, "[[", "source")
     ir_parse_error(sprintf("Duplicated function %s while reading includes",
                            paste(squote(dups), collapse = ", ")),
-                   ir_parse_error_lines(config), source)
+                   lines, source)
   }
 
   list(names = nms,
-       data = list(
-         source = unlist(lapply(res, attr, "source"))))
-}
-
-
-ir_parse_config_include_c <- function(config, root, source) {
-  if (length(config) == 0L) {
-    return(NULL)
-  }
-
-  read1 <- function(x) {
-    filename <- file.path(root, x$rhs$value)
-    if (!file.exists(filename)) {
-      ir_parse_error(
-        sprintf("Could not find file '%s' (relative to root '%s')",
-                x$rhs$value, root),
-        x$source, source)
-    }
-    tryCatch(
-      read_user_c(filename),
-      error = function(e)
-        ir_parse_error(paste("Could not read include file:", e$message),
-                       x$source, source))
-  }
-
-  ## TODO: this is more roundabout than needed - join_library should
-  ## be replaced to support this.
-  res <- join_library(lapply(config, read1))
-  if (any(duplicated(res$declarations))) {
-    ir_parse_error("Duplicate declarations while reading includes",
-                   ir_parse_error_lines(config), source)
-  }
-
-  declarations <- strsplit(res$declarations, "\n")
-  definitions <- strsplit(res$definitions, "\n")
-  data <- lapply(names(res$declarations), function(x)
-    list(name = x,
-         declaration = declarations[[x]],
-         definition = definitions[[x]]))
-  names(data) <- names(res$declarations)
-
-  list(names = names(data),
-       data = data)
+       data = lapply(res, "[[", "data"))
 }
 
 

--- a/R/ir_serialise.R
+++ b/R/ir_serialise.R
@@ -19,11 +19,7 @@ ir_serialise_version <- function(version) {
 
 
 ir_serialise_config <- function(config) {
-  include <- lapply(unname(config$include), function(x)
-    list(name = scalar(x$name),
-         declaration = x$declaration,
-         definition = x$definition))
-  list(base = scalar(config$base), include = include)
+  list(base = scalar(config$base), include = config$include)
 }
 
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -8,8 +8,8 @@ join_library <- function(x) {
 
 
 combine_include <- function(x) {
-  xx <- unique(unlist(x, FALSE))
-  nms <- vcapply(xx, "[[", "name")
+  xx <- unique(unname(unlist(x, FALSE)))
+  nms <- vcapply(xx, function(el) el$name[[1]])
   if (any(duplicated(nms))) {
     stop("Duplicated entries in included C support not allowed")
   }

--- a/R/misc.R
+++ b/R/misc.R
@@ -28,7 +28,6 @@ combine_include <- function(x) {
 }
 
 
-## TODO: compat
 read_user_c <- function(filename) {
   read_include_c(filename)$data
 }

--- a/R/misc.R
+++ b/R/misc.R
@@ -36,6 +36,23 @@ read_user_c <- function(filename) {
 }
 
 
+read_user_r <- function(filename) {
+  e <- new.env(parent = baseenv())
+  sys.source(filename, e)
+  name <- names(e)
+  defn <- readLines(filename)
+
+  ## We will take a different approach here to reading files to the C
+  ## version here; this is practically the same as what we will do in
+  ## the dust version, but we will use C++ attributes to indicate
+  ## which functions are for use.
+  ret <- rep(list(NULL), length(name))
+  names(ret) <- name
+  attr(ret, "source") <- readLines(filename)
+  ret
+}
+
+
 is_c_identifier <- function(x) {
   ## Keyword list from:
   ## http://en.cppreference.com/w/c/keyword

--- a/R/odin_options.R
+++ b/R/odin_options.R
@@ -41,12 +41,19 @@ odin_options <- function(verbose = NULL, target = NULL, workdir = NULL,
                  no_check_naked_index = no_check_naked_index,
                  compiler_warnings = compiler_warnings)
   }
-  stopifnot(setequal(names(defaults), names(options)))
+  stopifnot(all(names(defaults) %in% names(options)))
 
   for (i in names(defaults)) {
     if (is.null(options[[i]])) {
       options[[i]] <- getOption(paste0("odin.", i), defaults[[i]])
     }
   }
+
+  options$parse_include <- switch(
+    options$target,
+    c = ir_parse_config_include_c,
+    r = ir_parse_config_include_r,
+    ir_parse_config_include_unsupported(options$target))
+
   options
 }

--- a/R/odin_options.R
+++ b/R/odin_options.R
@@ -49,11 +49,11 @@ odin_options <- function(verbose = NULL, target = NULL, workdir = NULL,
     }
   }
 
-  options$parse_include <- switch(
+  options$read_include <- switch(
     options$target,
-    c = ir_parse_config_include_c,
-    r = ir_parse_config_include_r,
-    ir_parse_config_include_unsupported(options$target))
+    c = read_include_c,
+    r = read_include_r,
+    read_include_unsupported(options$target))
 
   options
 }

--- a/R/odin_options.R
+++ b/R/odin_options.R
@@ -49,11 +49,13 @@ odin_options <- function(verbose = NULL, target = NULL, workdir = NULL,
     }
   }
 
-  options$read_include <- switch(
-    options$target,
-    c = read_include_c,
-    r = read_include_r,
-    read_include_unsupported(options$target))
+  if (is.null(options$read_include)) {
+    options$read_include <- switch(
+      options$target,
+      c = read_include_c,
+      r = read_include_r,
+      read_include_unsupported(options$target))
+  }
 
   options
 }

--- a/inst/schema.json
+++ b/inst/schema.json
@@ -147,10 +147,10 @@
                     "type": "string"
                 },
                 "include": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/include"
-                    }
+                    "oneOf": [
+                        {"$ref": "#/definitions/include"},
+                        {"type": "null"}
+                    ]
                 }
             },
             "required": ["base", "include"],
@@ -160,17 +160,13 @@
         "include": {
             "type": "object",
             "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "definition": {
+                "names": {
                     "$ref": "#/definitions/basic/character_vector"
                 },
-                "declaration": {
-                    "$ref": "#/definitions/basic/character_vector"
+                "data": {
                 }
             },
-            "required": ["name", "definition", "declaration"],
+            "required": ["names", "data"],
             "additionalProperties": false
         },
 

--- a/tests/testthat/test-odin-options.R
+++ b/tests/testthat/test-odin-options.R
@@ -6,3 +6,10 @@ test_that("can create placeholder handler for include parsing", {
     opts$read_include(),
     "'config(include)' is not supported for target 'fortran'", fixed = TRUE)
 })
+
+
+test_that("manually set parsing functions persist", {
+  opts <- odin_options(target = "fortran")
+  opts$read_include <- read_include_c
+  expect_identical(odin_options(options = opts)$read_include, read_include_c)
+})

--- a/tests/testthat/test-odin-options.R
+++ b/tests/testthat/test-odin-options.R
@@ -3,6 +3,6 @@ context("odin_options")
 test_that("can create placeholder handler for include parsing", {
   opts <- odin_options(target = "fortran")
   expect_error(
-    opts$parse_include(),
+    opts$read_include(),
     "'config(include)' is not supported for target 'fortran'", fixed = TRUE)
 })

--- a/tests/testthat/test-odin-options.R
+++ b/tests/testthat/test-odin-options.R
@@ -1,0 +1,8 @@
+context("odin_options")
+
+test_that("can create placeholder handler for include parsing", {
+  opts <- odin_options(target = "fortran")
+  expect_error(
+    opts$parse_include(),
+    "'config(include)' is not supported for target 'fortran'", fixed = TRUE)
+})

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -105,6 +105,19 @@ test_that("pathalogical user c", {
 })
 
 
+test_that("allow reuse of user eqs", {
+  skip_on_windows_gha()
+  tmp <- file.path(tempdir(), "pulse2.R")
+  txt <- file.copy("pkg/inst/odin/pulse.R", tmp, overwrite = TRUE)
+  path <- c("pkg/inst/odin/pulse.R", tmp, "user_fns.c")
+  res <- odin_create_package("pulse", path)
+
+  t <- seq(0, 3, length.out = 301)
+  expect_equal(
+    res$env$pulse()$run(t),
+    res$env$pulse2()$run(t))
+})
+
 test_that("error cases", {
   name <- "example"
   pkg <- file.path(tempfile(), name)

--- a/tests/testthat/test-parse2-config.R
+++ b/tests/testthat/test-parse2-config.R
@@ -46,16 +46,18 @@ test_that("config(base)", {
 })
 
 test_that("config(include)", {
-  expect_error(odin_parse_(quote(config(include) <- 1)),
+  options <- odin_options(target = "c")
+  expect_error(odin_parse_(quote(config(include) <- 1), options),
                "Expected a character for config(include)",
                fixed = TRUE, class = "odin_error")
 
-  expect_error(odin_parse_(quote(config(include) <- "no file.c")),
+  expect_error(odin_parse_(quote(config(include) <- "no file.c"), options),
                "Could not find file 'no file.c'",
                fixed = TRUE, class = "odin_error")
 
   expect_error(odin_parse(
-    'config(include) <- "user_fns.c"; config(include) <- "user_fns.c"'),
-    "Duplicate declarations while reading includes",
+    'config(include) <- "user_fns.c"; config(include) <- "user_fns.c"',
+    options),
+    "Duplicated function 'squarepulse' while reading includes",
     class = "odin_error")
 })

--- a/tests/testthat/test-parse2-general.R
+++ b/tests/testthat/test-parse2-general.R
@@ -276,7 +276,7 @@ test_that("custom functions ignore arrays", {
   expr <- quote(x)
   ia <- character(0)
   source <- "x"
-  include <- list(f = NULL)
+  include <- "f"
 
   expect_null(ir_parse_arrays_check_rhs(quote(a + b[1]), c(b = 1), ia,
                                         include, eq, source))
@@ -284,6 +284,9 @@ test_that("custom functions ignore arrays", {
                                         include, eq, source))
   expect_null(ir_parse_arrays_check_rhs(quote(f(a, b)), c(b = 1), ia,
                                         include, eq, source))
+  expect_error(ir_parse_arrays_check_rhs(quote(g(a, b)), c(b = 1), ia,
+                                         include, eq, source),
+               "Array 'b' used without array index")
 })
 
 test_that("lhs array checking", {

--- a/tests/testthat/test-parse2-general.R
+++ b/tests/testthat/test-parse2-general.R
@@ -228,47 +228,62 @@ test_that("RHS array checking", {
   ##
   ## TODO: I would prefer this to go all the way from odin_parse
   expect_null(ir_parse_arrays_check_rhs(quote(a + b[1]), c(b = 1), ia,
-                                        eq, source))
+                                        NULL, eq, source))
   expect_error(ir_parse_arrays_check_rhs(quote(a + b[1]), c(b = 2), ia,
-                                         eq, source),
+                                         NULL, eq, source),
                "Incorrect dimensionality for 'b'", class = "odin_error")
   expect_error(ir_parse_arrays_check_rhs(quote(a + b[1, 2, 3]), c(b = 2), ia,
-                                         eq, source),
+                                         NULL, eq, source),
                "Incorrect dimensionality for 'b'", class = "odin_error")
   expect_null(ir_parse_arrays_check_rhs(quote(a + b[1, 2, 3]), c(b = 3), ia,
-                                        eq, source))
+                                        NULL, eq, source))
   expect_error(ir_parse_arrays_check_rhs(quote(a + b[f(1)]), c(b = 1), ia,
-                                         eq, source),
+                                         NULL, eq, source),
                "Disallowed functions used for b", class = "odin_error")
   expect_error(ir_parse_arrays_check_rhs(quote(b), c(b = 1), ia,
-                                         eq, source),
+                                         NULL, eq, source),
                "Array 'b' used without array index", class = "odin_error")
   expect_null(ir_parse_arrays_check_rhs(quote(a), c(b = 1), ia,
-                                        eq, source))
+                                        NULL, eq, source))
   expect_error(ir_parse_arrays_check_rhs(quote(a[]), c(a = 1), ia,
-                                         eq, source),
+                                         NULL, eq, source),
                "Empty array index not allowed on rhs", class = "odin_error")
 
   rhs <- ir_parse_expr_rhs_expression_sum(quote(sum(a)))
-  expect_null(ir_parse_arrays_check_rhs(rhs, c(a = 1), ia, eq, source))
-  expect_error(ir_parse_arrays_check_rhs(rhs, c(b = 1), ia, eq, source),
+  expect_null(ir_parse_arrays_check_rhs(rhs, c(a = 1), ia, NULL, eq, source))
+  expect_error(ir_parse_arrays_check_rhs(rhs, c(b = 1), ia, NULL, eq, source),
                "Function 'sum' requires array as argument 1",
                class = "odin_error")
 
   rhs <- ir_parse_expr_rhs_expression_sum(quote(sum(a[])))
-  expect_error(ir_parse_arrays_check_rhs(rhs, c(b = 1), ia, eq, source),
+  expect_error(ir_parse_arrays_check_rhs(rhs, c(b = 1), ia, NULL, eq, source),
                "Function 'sum' requires array as argument 1",
                class = "odin_error")
 
   expr <- quote(sum(a[, ]))
   rhs <- ir_parse_expr_rhs_expression_sum(expr)
-  expect_error(ir_parse_arrays_check_rhs(rhs, c(a = 1), ia, eq, source),
+  expect_error(ir_parse_arrays_check_rhs(rhs, c(a = 1), ia, NULL, eq, source),
                "Incorrect dimensionality for 'a' in 'sum' (expected 1)",
                fixed = TRUE, class = "odin_error")
-  expect_silent(ir_parse_arrays_check_rhs(rhs, c(a = 2), ia, eq, source))
-  expect_error(ir_parse_arrays_check_rhs(rhs, c(a = 3), ia, eq, source),
+  expect_silent(ir_parse_arrays_check_rhs(rhs, c(a = 2), ia, NULL, eq, source))
+  expect_error(ir_parse_arrays_check_rhs(rhs, c(a = 3), ia, NULL, eq, source),
                "Incorrect dimensionality for 'a' in 'sum' (expected 3)",
                fixed = TRUE, class = "odin_error")
+})
+
+test_that("custom functions ignore arrays", {
+  eq <- list(source = 1)
+  expr <- quote(x)
+  ia <- character(0)
+  source <- "x"
+  include <- list(f = NULL)
+
+  expect_null(ir_parse_arrays_check_rhs(quote(a + b[1]), c(b = 1), ia,
+                                        include, eq, source))
+  expect_null(ir_parse_arrays_check_rhs(quote(f(a, b[1])), c(b = 1), ia,
+                                        include, eq, source))
+  expect_null(ir_parse_arrays_check_rhs(quote(f(a, b)), c(b = 1), ia,
+                                        include, eq, source))
 })
 
 test_that("lhs array checking", {

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -1306,3 +1306,24 @@ test_that_odin("force integer on a numeric vector truncates", {
   expect_equal(gen(idx = 3 - 1e-8)$initial(0), 2)
   expect_equal(gen(idx = 3 + 1e-8)$initial(0), 3)
 })
+
+
+test_that("user c functions can be passed arrays and indexes", {
+  skip_for_target("r")
+  gen <- odin({
+    config(include) <- "user_fns4.c"
+    n <- 5
+    x[] <- user()
+    y[] <- f(i, x)
+    dim(x) <- n
+    dim(y) <- n
+    output(y) <- TRUE
+    initial(a) <- 0
+    deriv(a) <- 0
+  })
+
+  x <- runif(5)
+  mod <- gen(user = list(x = x))
+  y <- mod$run(c(0, 1))
+  expect_equal(mod$transform_variables(y[2, ])$y, cumsum(x))
+})

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -209,7 +209,7 @@ test_that_odin("user c", {
     output(z) <- z
     deriv(y) <- z
     initial(y) <- 0
-  }, target = "c")
+  })
 
   mod <- gen()
   t <- seq(0, 3, length.out = 301)
@@ -231,7 +231,7 @@ test_that_odin("user r", {
     output(z) <- z
     deriv(y) <- z
     initial(y) <- 0
-  }, target = "r")
+  })
 
   mod <- gen()
   t <- seq(0, 3, length.out = 301)

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -209,7 +209,29 @@ test_that_odin("user c", {
     output(z) <- z
     deriv(y) <- z
     initial(y) <- 0
-  })
+  }, target = "c")
+
+  mod <- gen()
+  t <- seq(0, 3, length.out = 301)
+  y <- mod$run(t)
+
+  expect_equal(y[, 3L], as.numeric(t >= 1 & t < 2))
+  cmp <- -1 + t
+  cmp[t < 1] <- 0
+  cmp[t > 2] <- 1
+  expect_equal(y[, 2L], cmp, tolerance = 1e-5)
+})
+
+test_that_odin("user r", {
+  ## mrc-2027 would minimise duplication here
+  skip_for_target("c")
+  gen <- odin({
+    config(include) <- "user_fns.R"
+    z <- squarepulse(t, 1, 2)
+    output(z) <- z
+    deriv(y) <- z
+    initial(y) <- 0
+  }, target = "r")
 
   mod <- gen()
   t <- seq(0, 3, length.out = 301)

--- a/tests/testthat/user_fns.R
+++ b/tests/testthat/user_fns.R
@@ -1,0 +1,3 @@
+squarepulse <- function(t, t0, t1) {
+  t >= t0 && t < t1
+}

--- a/tests/testthat/user_fns4.c
+++ b/tests/testthat/user_fns4.c
@@ -1,0 +1,8 @@
+// A little example function that uses a vector.
+double f(size_t i, double *x) {
+  double n = 0;
+  for (size_t j = 0; j < i; ++j) {
+    n += x[j];
+  }
+  return n;
+}


### PR DESCRIPTION
This PR expands support for odin's nascent `config(include) <- filename` support:

* custom functions can be passed arrays in their entirety 
* support for non-C targets, with R supported here

See https://github.com/mrc-ide/odin.dust/pull/40 for an example in odin.dust, which is the motivating reason for this PR