### PR TITLE
mrc-2092: Add "stage" information into the IR

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.1.4
+Version: 1.1.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/R/common.R
+++ b/R/common.R
@@ -7,6 +7,7 @@ STAGE_NULL <- 0L
 STAGE_CONSTANT <- 1L
 STAGE_USER <- 2L
 STAGE_TIME <- 3L
+STAGE_NAME <- c("null", "constant", "user", "time")
 
 TIME <- "t"
 STEP <- "step"

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -148,8 +148,10 @@ ir_parse_data_element <- function(x, stage) {
     dimnames <- x$array$dimnames
   }
 
+  stage <- stage[[x$name]]
+
   if (is.null(x$lhs$special)) {
-    if (rank == 0L && stage[[x$name]] == STAGE_TIME) {
+    if (rank == 0L && stage == STAGE_TIME) {
       location <- "transient"
     } else {
       location <- "internal"
@@ -167,6 +169,7 @@ ir_parse_data_element <- function(x, stage) {
 
   list(name = name,
        location = location,
+       stage = stage,
        storage_type = storage_type,
        rank = rank,
        dimnames = dimnames)

--- a/R/ir_serialise.R
+++ b/R/ir_serialise.R
@@ -64,6 +64,7 @@ ir_serialise_data <- function(data) {
       ret$dimnames <- x$dimnames
       ret$dimnames$length <- ir_serialise_expression(x$dimnames$length)
     }
+    ret$stage <- scalar(names(STAGE_NAME)[x$stage + 1L])
     ret
   }
   ## TODO: this can be modified later on when we move initial out of

--- a/R/ir_serialise.R
+++ b/R/ir_serialise.R
@@ -64,7 +64,7 @@ ir_serialise_data <- function(data) {
       ret$dimnames <- x$dimnames
       ret$dimnames$length <- ir_serialise_expression(x$dimnames$length)
     }
-    ret$stage <- scalar(names(STAGE_NAME)[x$stage + 1L])
+    ret$stage <- scalar(STAGE_NAME[x$stage + 1L])
     ret
   }
   ## TODO: this can be modified later on when we move initial out of

--- a/inst/schema.json
+++ b/inst/schema.json
@@ -73,7 +73,7 @@
 
             "stage": {
                 "type": "string",
-                "enum": ["constant", "user", "time", "output"]
+                "enum": ["null", "constant", "user", "time"]
             },
 
             "index": {
@@ -235,6 +235,9 @@
                 },
                 "storage_type": {
                     "$ref": "#/definitions/enum/storage_type"
+                },
+                "stage": {
+                    "$ref": "#/definitions/enum/stage"
                 },
                 "rank": {
                     "type": "integer",

--- a/tests/testthat/test-ir.R
+++ b/tests/testthat/test-ir.R
@@ -9,3 +9,11 @@ test_that("deserialise", {
   res <- odin_ir_deserialise(ir)
   expect_identical(res$ir, ir)
 })
+
+
+test_that("Stage information included in IR", {
+  ir <- odin_parse_("examples/array_odin.R")
+  dat <- odin_ir_deserialise(ir)
+  expect_equal(dat$data$elements$dim_S$stage, "constant")
+  expect_equal(dat$data$elements$I_tot$stage, "time")
+})


### PR DESCRIPTION
Clearly this was meant to be here as the enum was there in the schema,
but never got added properly. This is needed for some optimisations in
odin.dust