### PR TITLE
Control notes about unused variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.1.7
+Version: 1.1.8
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin 1.1.8
+
+* Annotate equations with `# ignore.unused` to locally suppress messages about unused variables (mrc-2122)
+
 # odin 1.1.6
 
 * odin no longer warns about use of index variables on rhs as new behaviour has been established for a while (#136)


### PR DESCRIPTION
This is intended to support compare functions as introduced in dust and supported by odin.dust. In this case we want to mark some equations as allowably unused and suppress a message about an unused variable.

This can be seen fairly easily in the tests, I think.

Note that this does not work with inline odin definitions like:

```
odin({
  initial(x) <- 1 
  update(x) <- 1
  a <- 1 # ignore.unused
})
```

because the comment will be lost. However, it is preserved where the model is loaded from file or defined in text.
