### PR TITLE
mrc-2251: add support for as.numeric

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.1.9
+Version: 1.1.10
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/R/common.R
+++ b/R/common.R
@@ -106,6 +106,7 @@ FUNCTIONS <- list(
   floor = 1L,
   ceil = 1L,
   as.integer = 1L,
+  as.numeric = 1L,
   ## Big pile of trig:
   cos = 1L,   sin = 1L,   tan = 1L,
   acos = 1L,  asin = 1L,  atan = 1L,  atan2 = 2L,

--- a/R/generate_c_sexp.R
+++ b/R/generate_c_sexp.R
@@ -45,6 +45,8 @@ generate_c_sexp <- function(x, data, meta, supported) {
       ret <- generate_c_sexp_sum(args, data, meta, supported)
     } else if (fn == "as.integer") {
       ret <- sprintf("(int) (%s)", values[[1L]])
+    } else if (fn == "as.numeric") {
+      ret <- sprintf("(double) (%s)", values[[1L]])
     } else {
       if (fn == "rbinom") {
         ## This is a little extreme but is useful in at least some

--- a/tests/testthat/test-run-library.R
+++ b/tests/testthat/test-run-library.R
@@ -234,3 +234,16 @@ test_that_odin("Throw an error if requesting more elements than possible", {
                "Requesting too many elements in rmhyper (10 from 0)",
                fixed = TRUE)
 })
+
+
+test_that_odin("Can use as.numeric", {
+  gen <- odin({
+    a <- user(integer = TRUE)
+    b <- as.numeric(a)
+    initial(x) <- 0
+    update(x) <- x + b
+  })
+  mod <- gen(a = 5L)
+  y <- mod$run(0:10)
+  expect_equal(y[, "x"], seq(0, 50, by = 5))
+})


### PR DESCRIPTION
Just passes this through as.numeric to a c cast to double. It's really needed for odin.dust

Merge after #219 