### PR TITLE
Allow substitution of user values at compile time

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.1.10
+Version: 1.1.11
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin 1.1.11
+
+* New option `substitutions` (via `odin::odin_options`) which can substitute in scalar `user` values at compile time (#220)
+
 # odin 1.1.9
 
 * New option `rewrite_dims` (via `odin::odin_options`) which will attempt to simplify common dimensions. This can reduce the number of variables carried around in the model as these are typically very redundant and also known at compile time (mrc-2093)

--- a/R/odin_parse.R
+++ b/R/odin_parse.R
@@ -61,5 +61,6 @@ odin_parse <- function(x, type = NULL, options = NULL) {
 ##' @rdname odin_parse
 odin_parse_ <- function(x, options = NULL, type = NULL) {
   options <- odin_options(options = options)
+  assert_scalar_character_or_null(type)
   ir_parse(x, options, type)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -245,7 +245,7 @@ na_drop <- function(x) {
 
 assert_scalar_logical_or_null <- function(x, name = deparse(substitute(x))) {
   if (!is.null(x)) {
-    if (length(x) != 1 || !is.logical(x) || !is.na(x)) {
+    if (length(x) != 1 || !is.logical(x) || is.na(x)) {
       stop(sprintf("Expected '%s' to be a logical scalar (or NULL)", name))
     }
   }
@@ -253,11 +253,31 @@ assert_scalar_logical_or_null <- function(x, name = deparse(substitute(x))) {
 }
 
 
-assert_scalar_logical_or_null <- function(x, name = deparse(substitute(x))) {
+assert_scalar_character_or_null <- function(x, name = deparse(substitute(x))) {
   if (!is.null(x)) {
-    if (length(x) != 1 || !is.logical(x) || is.na(x)) {
-      stop(sprintf("Expected '%s' to be a logical scalar (or NULL)", name))
+    if (length(x) != 1 || !is.character(x) || is.na(x)) {
+      stop(sprintf("Expected '%s' to be a character scalar (or NULL)", name))
     }
+  }
+  invisible(x)
+}
+
+
+assert_named <- function(x, unique = FALSE, name = deparse(substitute(x))) {
+  if (is.null(names(x))) {
+    stop(sprintf("'%s' must be named", name), call. = FALSE)
+  }
+  if (unique && any(duplicated(names(x)))) {
+    stop(sprintf("'%s' must have unique names", name), call. = FALSE)
+  }
+  invisible(x)
+}
+
+
+assert_is <- function(x, what, name = deparse(substitute(x))) {
+  if (!inherits(x, what)) {
+    stop(sprintf("'%s' must be a %s", name, paste(what, collapse = " / ")),
+         call. = FALSE)
   }
   invisible(x)
 }

--- a/man/odin_options.Rd
+++ b/man/odin_options.Rd
@@ -7,7 +7,7 @@
 odin_options(verbose = NULL, target = NULL, workdir = NULL,
   validate = NULL, pretty = NULL, skip_cache = NULL,
   compiler_warnings = NULL, no_check_unused_equations = NULL,
-  rewrite_dims = NULL, options = NULL)
+  rewrite_dims = NULL, substitutions = NULL, options = NULL)
 }
 \arguments{
 \item{verbose}{Logical scalar indicating if the compilation should
@@ -52,6 +52,12 @@ integers, and those known at initialisation with simplified and
 shared expressions. You may get less-comprehensible error
 messages with this option set to \code{TRUE} because parts of the
 model have been effectively evaluated during processing.}
+
+\item{substitutions}{Optionally, a list of values to substitute into
+model specification as constants, even though they are declared
+as \code{user()}. This will be most useful in conjunction with
+\code{rewrite_dims} to create a copy of your model with dimensions
+known at compile time and all loops using literal integers.}
 
 \item{options}{Named list of options.  If provided, then all other
 options are ignored.}

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -739,3 +739,26 @@ test_that_odin("Can set initial conditions directly in an ode", {
   y <- mod$run(0:10, 2)
   expect_equal(y[, "y"], seq(2, by = 2, length.out = 11))
 })
+
+
+test_that_odin("Can substitute user variables", {
+  gen <- odin({
+    n <- user(integer = TRUE)
+    m <- user()
+    deriv(S[, ]) <- 0
+    deriv(I) <- S[n, m]
+    dim(S) <- c(n, m)
+    initial(S[, ]) <- S0[i, j]
+    initial(I) <- 0
+    S0[, ] <- user()
+    dim(S0) <- c(n, m)
+  }, options = odin_options(rewrite_dims = TRUE,
+                            substitutions = list(n = 2, m = 3)))
+  expect_equal(nrow(coef(gen)), 1) # only S0 now
+  S0 <- matrix(rpois(6, 10), 2, 3)
+  mod <- gen(S0 = S0)
+  dat <- mod$contents()
+  expect_equal(dat$n, 2)
+  expect_equal(dat$m, 3)
+  expect_equal(dat$initial_S, S0)
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -178,3 +178,43 @@ test_that("validate inputs", {
   expect_error(assert_scalar_logical_or_null(logical(0)),
                "Expected '.+' to be a logical scalar \\(or NULL\\)")
 })
+
+
+test_that("validate inputs", {
+  expect_silent(assert_scalar_character_or_null(NULL))
+  expect_silent(assert_scalar_character_or_null("a"))
+
+  thing <- TRUE
+  expect_error(
+    assert_scalar_character_or_null(thing),
+    "Expected 'thing' to be a character scalar (or NULL)",
+    fixed = TRUE)
+  expect_error(assert_scalar_character_or_null(NA),
+               "Expected '.+' to be a character scalar \\(or NULL\\)")
+  expect_error(assert_scalar_character_or_null(character(0)),
+               "Expected '.+' to be a character scalar \\(or NULL\\)")
+})
+
+
+test_that("check names", {
+  expect_error(
+    assert_named(list()),
+    "must be named")
+  expect_error(
+    assert_named(list(1, 2)),
+    "must be named")
+  expect_silent(
+    assert_named(list(a = 1, a = 2)))
+  expect_error(
+    assert_named(list(a = 1, a = 2), TRUE),
+    "must have unique names")
+})
+
+
+test_that("Check S3 class", {
+  expect_silent(assert_is(structure(1, class = "foo"), "foo"))
+  expect_error(assert_is(structure(1, class = "bar"), "foo"),
+               "must be a foo")
+  expect_error(assert_is(1, c("foo", "bar")),
+               "must be a foo / bar")
+})


### PR DESCRIPTION
This PR allows substitutions of user values at compile time. So if the model contains

```
a <- user()
```

then we might provide `substitutions = list(a = 10)` and we rewrite this as if the user had written

```
a <- 10
```

This will be most useful with `rewrite_dims` because then we'd be able to follow this through to make arrays compile-time-sized

Fixes #220 