### PR TITLE
Detect vector copy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.1.14
+Version: 1.1.15
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/R/compat.R
+++ b/R/compat.R
@@ -27,8 +27,9 @@ print.odin_generator <- function(x, ...) {
 
 deprecated_constructor_call <- function(name) {
   calls <- sys.calls()
-  if (length(calls) >= 2 && is.symbol(calls[[length(calls) - 1L]][[1]])) {
-    nm <- as.character(calls[[length(calls) - 1L]][[1]])
+  n <- length(calls) - 1L # second to last call would be us
+  if (n >= 1 && is.symbol(calls[[n]][[1]])) {
+    nm <- as.character(calls[[n]][[1]])
   } else {
     nm <- name
   }

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -627,9 +627,13 @@ ir_parse_expr <- function(expr, line, source) {
     copy_expr <- as.name(lhs$name_data)
     if (type == "expression_array") {
       copy_expr_index <- lapply(INDEX[seq_along(lhs$index)[[1]]], as.name)
-      copy_expr <- as.call(c(as.name("["), copy_expr, copy_expr_index))
+      copy_expr_array <- as.call(c(as.name("["), copy_expr, copy_expr_index))
+    } else {
+      copy_expr_array <- copy_expr
     }
-    is_copy <- isTRUE(rhs$rhs$value) || identical(rhs$rhs$value, copy_expr)
+    is_copy <- isTRUE(rhs$rhs$value) ||
+      identical(rhs$rhs$value, copy_expr) ||
+      identical(rhs$rhs$value, copy_expr_array)
     if (is_copy) {
       type <- "copy"
       depends <- list(functions = character(0), variables = lhs$name_data)

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -624,8 +624,12 @@ ir_parse_expr <- function(expr, line, source) {
   }
 
   if (identical(lhs$special, "output")) {
-    is_copy <-
-      isTRUE(rhs$rhs$value) || identical(rhs$rhs$value, as.name(lhs$name_data))
+    copy_expr <- as.name(lhs$name_data)
+    if (type == "expression_array") {
+      copy_expr_index <- lapply(INDEX[seq_along(lhs$index)[[1]]], as.name)
+      copy_expr <- as.call(c(as.name("["), copy_expr, copy_expr_index))
+    }
+    is_copy <- isTRUE(rhs$rhs$value) || identical(rhs$rhs$value, copy_expr)
     if (is_copy) {
       type <- "copy"
       depends <- list(functions = character(0), variables = lhs$name_data)

--- a/tests/testthat/test-run-basic.R
+++ b/tests/testthat/test-run-basic.R
@@ -221,6 +221,24 @@ test_that_odin("copy output", {
 })
 
 
+test_that_odin("copy output, explicitly", {
+  gen <- odin({
+    deriv(y) <- 1
+    initial(y) <- 1
+    z[] <- t
+    dim(z) <- 5
+    output(z[]) <- z[i]
+  })
+
+  mod <- gen$new()
+  tt <- 0:10
+  y <- mod$run(tt)
+  yy <- mod$transform_variables(y)
+  expect_equal(yy$y, tt + 1)
+  expect_equal(yy$z, matrix(tt, length(tt), 5))
+})
+
+
 ## Basic discrete models
 test_that_odin("discrete", {
   gen <- odin({


### PR DESCRIPTION
Looks like we should detect

```
output(a[]) <- a[i]
```

too - this is likely to be more error prone than the recommended

```
output(a[]) <- TRUE
```

though

Fixes #228