### PR TITLE
Start support for array sum optimisation

### DIFF
--- a/R/generate_c_equation.R
+++ b/R/generate_c_equation.R
@@ -80,13 +80,7 @@ generate_c_equation_inplace_rmhyper <- function(eq, lhs, data_info, dat,
 
 
 generate_c_equation_array <- function(eq, data_info, dat, rewrite) {
-  ## TODO: Which of these is correct? first only?
-  if (eq$type == "expression_array") {
-    index <- vcapply(eq$rhs[[1]]$index, "[[", "index")
-  } else {
-    index <- lapply(eq$rhs$index, "[[", "index")
-  }
-
+  index <- vcapply(eq$rhs[[1]]$index, "[[", "index")
   lhs <- generate_c_equation_array_lhs(index, data_info, dat, rewrite)
   lapply(eq$rhs, function(x)
     generate_c_equation_array_rhs(x$value, x$index, lhs, rewrite))
@@ -362,12 +356,7 @@ generate_c_equation_delay_continuous <- function(eq, data_info, dat, rewrite) {
     lhs <- rewrite(eq$lhs)
     expr <- sprintf_safe("%s = %s;", lhs, rewrite(rhs_expr))
   } else {
-    ## TODO: which of these is correct?
-    if (eq$type == "expression_array") {
-      index <- vcapply(eq$rhs[[1]]$index, "[[", "index")
-    } else {
-      index <- lapply(eq$rhs$index, "[[", "index")
-    }
+    index <- lapply(eq$rhs$index, "[[", "index")
     lhs <- generate_c_equation_array_lhs(index, data_info, dat, rewrite)
     expr <- generate_c_equation_array_rhs(rhs_expr, eq$rhs$index, lhs, rewrite)
   }
@@ -441,13 +430,9 @@ generate_c_equation_delay_discrete <- function(eq, data_info, dat, rewrite) {
   } else {
     data_info_ring <- data_info
     data_info_ring$name <- head
-    ## TODO: which one of these is correct?
-    if (eq$type == "expression_array") {
-      index <- vcapply(eq$rhs[[1]]$index, "[[", "index")
-    } else {
-      index <- lapply(eq$rhs$index, "[[", "index")
-    }
-    lhs_ring <- generate_c_equation_array_lhs(index, data_info_ring, dat, rewrite)
+    index <- lapply(eq$rhs$index, "[[", "index")
+    lhs_ring <- generate_c_equation_array_lhs(index, data_info_ring, dat,
+                                              rewrite)
     push <- generate_c_equation_array_rhs(eq$rhs$value, eq$rhs$index,
                                           lhs_ring, rewrite)
   }

--- a/R/generate_c_sexp.R
+++ b/R/generate_c_sexp.R
@@ -107,17 +107,17 @@ generate_c_sexp_sum <- function(args, data, meta, supported) {
 
 generate_c_sexp_index <- function(x, rewrite) {
   if (is.recursive(x)) {
-    stopifnot(length(x) == 3)
     fn <- x[[1L]]
     args <- vcapply(x[-1L], generate_c_sexp_index, rewrite)
     if (fn == "(") {
       sprintf("(%s)", args[[1L]])
     } else {
+      stopifnot(length(x) == 3)
       fn_c <- switch(fn,
                      "%%" = "%",
                      "%/%" = "/",
                      "+" = "+",
-                     "(" = "(",
+                     "*" = "*",
                      stop("unhandled"))
       sprintf("%s %s %s", args[[1L]], fn_c, args[[2L]])
     }

--- a/R/generate_c_sexp.R
+++ b/R/generate_c_sexp.R
@@ -103,3 +103,25 @@ generate_c_sexp_sum <- function(args, data, meta, supported) {
     sprintf_safe("odin_sum%d(%s)", length(i), arg_str)
   }
 }
+
+
+generate_c_sexp_index <- function(x, rewrite) {
+  if (is.recursive(x)) {
+    stopifnot(length(x) == 3)
+    fn <- x[[1L]]
+    args <- vcapply(x[-1L], generate_c_sexp_index, rewrite)
+    if (fn == "(") {
+      sprintf("(%s)", args[[1L]])
+    } else {
+      fn_c <- switch(fn,
+                     "%%" = "%",
+                     "%/%" = "/",
+                     "+" = "+",
+                     "(" = "(",
+                     stop("unhandled"))
+      sprintf("%s %s %s", args[[1L]], fn_c, args[[2L]])
+    }
+  } else {
+    rewrite(x)
+  }
+}

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -778,7 +778,7 @@ ir_parse_expr_lhs_index <- function(lhs, line, source) {
   tmp <- lapply(index, ir_parse_expr_lhs_check_index)
   err <- !vlapply(tmp, as.logical)
   if (any(err)) {
-    msg <- paste0("\t\t", vcapply(tmp[!ok], attr, "message"), collapse = "\n")
+    msg <- paste0("\t\t", vcapply(tmp[err], attr, "message"), collapse = "\n")
     ir_parse_error(sprintf("Invalid array use on lhs:\n%s", msg),
                    line, source)
   }

--- a/R/ir_parse_arrays.R
+++ b/R/ir_parse_arrays.R
@@ -885,10 +885,15 @@ ir_parse_rewrite_sums1 <- function(x, data, source) {
     return(x)
   }
 
-  res <- factor_sum(x$rhs[[1]]$value, data)
-  if (is.null(res)) {
+  res <- factor_sum(x$rhs[[1L]]$value, data)
+
+  if (is.null(res$sum)) {
     ## Could not work out a nice sum here.
     return(x)
+  }
+
+  if (!is.null(res$base)) {
+    res$base <- list(index = x$rhs[[1L]]$index, value = res$base)
   }
 
   x$type <- "expression_array_sum"

--- a/R/ir_parse_arrays.R
+++ b/R/ir_parse_arrays.R
@@ -938,8 +938,6 @@ check_sum <- function(expr, data) {
 
 
 factor_sum <- function(expr, data) {
-  stopifnot(is.recursive(expr))
-
   fn <- if (is.recursive(expr)) deparse_str(expr[[1L]]) else ""
 
   join_expr <- function(a, b, fn) {

--- a/R/ir_parse_arrays.R
+++ b/R/ir_parse_arrays.R
@@ -1010,7 +1010,7 @@ array_sum_lhs_index <- function(key, info) {
       stop("Unsupported"))
     subs <- list(d1 = as_name(info$dimnames$dim[[1]]),
                  d2 = as_name(info$dimnames$dim[[2]]),
-                 d12 = as_name(info$dimnames$mult[[2]]))
+                 d12 = as_name(info$dimnames$mult[[3]]))
   } else {
     expr <- switch(
       key,
@@ -1046,8 +1046,8 @@ array_sum_lhs_index <- function(key, info) {
     subs <- list(d1 = as_name(info$dimnames$dim[[1]]),
                  d2 = as_name(info$dimnames$dim[[2]]),
                  d3 = as_name(info$dimnames$dim[[3]]),
-                 d12 = as_name(info$dimnames$mult[[2]]),
-                 d123 = as_name(info$dimnames$mult[[3]]))
+                 d12 = as_name(info$dimnames$mult[[3]]),
+                 d123 = as_name(info$dimnames$mult[[4]]))
   }
 
   substitute_(expr, subs)

--- a/R/ir_serialise.R
+++ b/R/ir_serialise.R
@@ -131,6 +131,7 @@ ir_serialise_equation <- function(eq) {
     delay_discrete = ir_serialise_delay_discrete(eq),
     delay_index = ir_serialise_equation_delay_index(eq),
     expression_array = ir_serialise_equation_expression_array(eq),
+    expression_array_sum = ir_serialise_equation_expression_array_sum(eq),
     expression_scalar = ir_serialise_equation_expression_scalar(eq),
     expression_inplace = ir_serialise_equation_expression_inplace(eq),
     interpolate = ir_serialise_equation_interpolate(eq),
@@ -181,6 +182,22 @@ ir_serialise_equation_expression_array <- function(eq) {
   }
   list(rhs = lapply(eq$rhs, rhs))
 }
+
+
+ir_serialise_equation_expression_array_sum <- function(eq) {
+  base <- eq$rhs$base
+  if (!is.null(base)) {
+    browser()
+  }
+
+  rhs_sum <- function(x) {
+    list(name = scalar(deparse_str(x$name)),
+         index = ir_serialise_expression(x$index))
+  }
+
+  list(rhs = list(base = base, sum = lapply(eq$rhs$sum, rhs_sum)))
+}
+
 
 ir_serialise_equation_interpolate <- function(eq) {
   list(interpolate = scalar(eq$interpolate))

--- a/R/ir_serialise.R
+++ b/R/ir_serialise.R
@@ -185,17 +185,12 @@ ir_serialise_equation_expression_array <- function(eq) {
 
 
 ir_serialise_equation_expression_array_sum <- function(eq) {
-  base <- eq$rhs$base
-  if (!is.null(base)) {
-    browser()
-  }
-
   rhs_sum <- function(x) {
     list(name = scalar(deparse_str(x$name)),
          index = ir_serialise_expression(x$index))
   }
-
-  list(rhs = list(base = base, sum = lapply(eq$rhs$sum, rhs_sum)))
+  list(rhs = list(base = ir_serialise_expression(eq$rhs$base),
+                  sum = lapply(eq$rhs$sum, rhs_sum)))
 }
 
 

--- a/R/ir_serialise.R
+++ b/R/ir_serialise.R
@@ -189,7 +189,17 @@ ir_serialise_equation_expression_array_sum <- function(eq) {
     list(name = scalar(deparse_str(x$name)),
          index = ir_serialise_expression(x$index))
   }
-  list(rhs = list(base = ir_serialise_expression(eq$rhs$base),
+  if (is.null(eq$rhs$base)) {
+    base <- NULL
+  } else {
+    base <- list(
+      index = lapply(eq$rhs$base$index, function(i)
+        list(value = ir_serialise_expression(i$value),
+             is_range = scalar(i$is_range),
+             index = scalar(i$index))),
+      value = ir_serialise_expression(eq$rhs$base$value))
+  }
+  list(rhs = list(base = base,
                   sum = lapply(eq$rhs$sum, rhs_sum)))
 }
 

--- a/R/odin_options.R
+++ b/R/odin_options.R
@@ -30,6 +30,11 @@
 ##'   dimensions known at compile time and all loops using literal
 ##'   integers.
 ##'
+##' @param rewrite_sums Logical, indicating if we should try and
+##'   rewrite expressions involving "partial sums" (e.g, `x[] <-
+##'   sum(y[i, ])`) in a more optimised way. This may not always be
+##'   possible.
+##'
 ##' @return A list of parameters, of class `odin_options`
 ##'
 ##' @export
@@ -40,7 +45,8 @@ odin_options <- function(verbose = NULL, target = NULL, workdir = NULL,
                          compiler_warnings = NULL,
                          no_check_unused_equations = NULL,
                          rewrite_dims = NULL, rewrite_constants = NULL,
-                         substitutions = NULL, options = NULL) {
+                         substitutions = NULL, rewrite_sums = NULL,
+                         options = NULL) {
   default_target <-
     if (is.null(target) && !can_compile(verbose = FALSE)) "r" else "c"
   defaults <- list(
@@ -53,6 +59,7 @@ odin_options <- function(verbose = NULL, target = NULL, workdir = NULL,
     rewrite_dims = FALSE,
     rewrite_constants = FALSE,
     substitutions = NULL,
+    rewrite_sums = FALSE,
     no_check_unused_equations = FALSE,
     compiler_warnings = FALSE)
   if (is.null(options)) {
@@ -66,6 +73,7 @@ odin_options <- function(verbose = NULL, target = NULL, workdir = NULL,
       rewrite_dims = assert_scalar_logical_or_null(rewrite_dims),
       rewrite_constants = assert_scalar_logical_or_null(rewrite_constants),
       substitutions = check_substitutions(substitutions),
+      rewrite_sums = assert_scalar_logical_or_null(rewrite_sums),
       no_check_unused_equations =
         assert_scalar_logical_or_null(no_check_unused_equations),
       compiler_warnings = assert_scalar_logical_or_null(compiler_warnings))

--- a/inst/schema.json
+++ b/inst/schema.json
@@ -393,7 +393,7 @@
                 "base": {
                     "oneOf": [
                         {"type": "null"},
-                        {"type": "object"}
+                        {"$ref": "#/definitions/sexpression"}
                     ]
                 },
                 "sum": {

--- a/inst/schema.json
+++ b/inst/schema.json
@@ -370,21 +370,24 @@
 
         "equation_rhs_array": {
             "type": "array",
-            "TODO": "Factor out element definition for reuse",
             "items": {
-                "type": "object",
-                "properties": {
-                    "value": {
-                        "$ref": "#/definitions/sexpression"
-                    },
-                    "index": {
-                        "$ref": "#/definitions/equation_rhs_array_index"
-                    }
-                },
-                "required": ["value", "index"],
-                "additionalProperties": false
+                "$ref": "#/definitions/equation_rhs_array_element"
             },
             "minItems": 1
+        },
+
+        "equation_rhs_array_element": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "$ref": "#/definitions/sexpression"
+                },
+                "index": {
+                    "$ref": "#/definitions/equation_rhs_array_index"
+                }
+            },
+            "required": ["value", "index"],
+            "additionalProperties": false
         },
 
         "equation_rhs_array_sum": {
@@ -393,7 +396,7 @@
                 "base": {
                     "oneOf": [
                         {"type": "null"},
-                        {"$ref": "#/definitions/sexpression"}
+                        {"$ref": "#/definitions/equation_rhs_array_element"}
                     ]
                 },
                 "sum": {

--- a/inst/schema.json
+++ b/inst/schema.json
@@ -60,6 +60,7 @@
                     "interpolate",
                     "user",
                     "expression_array",
+                    "expression_array_sum",
                     "expression_inplace",
                     "expression_scalar"
                 ],
@@ -339,6 +340,7 @@
                         {"$ref": "#/definitions/equation_alloc_ring"},
                         {"$ref": "#/definitions/equation_user"},
                         {"$ref": "#/definitions/equation_expression_array"},
+                        {"$ref": "#/definitions/equation_expression_array_sum"},
                         {"$ref": "#/definitions/equation_expression_inplace"},
                         {"$ref": "#/definitions/equation_expression_scalar"},
                         {"$ref": "#/definitions/equation_interpolate"},
@@ -383,6 +385,37 @@
                 "additionalProperties": false
             },
             "minItems": 1
+        },
+
+        "equation_rhs_array_sum": {
+            "type": "object",
+            "properties": {
+                "base": {
+                    "oneOf": [
+                        {"type": "null"},
+                        {"type": "object"}
+                    ]
+                },
+                "sum": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "index": {
+                                "$ref": "#/definitions/sexpression"
+                            }
+                        },
+                        "required": ["name", "index"],
+                        "additionalProperties": false
+                    },
+                    "minItems": 1
+                }
+            },
+            "required": ["base", "sum"],
+            "additionalProperties": false
         },
 
         "equation_rhs_delay_continuous": {
@@ -566,6 +599,20 @@
                 "depends": {},
                 "lhs": {},
                 "rhs": {"$ref": "#/definitions/equation_rhs_array"}
+            },
+            "required": ["type", "rhs"],
+            "additionalProperties": false
+        },
+
+        "equation_expression_array_sum": {
+            "type": "object",
+            "properties": {
+                "type": {"const": "expression_array_sum"},
+                "name": {},
+                "source": {},
+                "depends": {},
+                "lhs": {},
+                "rhs": {"$ref": "#/definitions/equation_rhs_array_sum"}
             },
             "required": ["type", "rhs"],
             "additionalProperties": false

--- a/tests/testthat/test-opt.R
+++ b/tests/testthat/test-opt.R
@@ -221,7 +221,7 @@ test_that("factorise sums where possible", {
                                b = array_data("a", 3),
                                m = array_data("m", 2)))
   sum_a <- list(name = quote(a),
-                index = quote((i %/% dim_a_1) * dim_a_1 + i %% dim_a_1))
+                index = quote((i %/% dim_a_12) * dim_a_1 + i %% dim_a_1))
   expect_equal(
     factor_sum(quote(odin_sum(a, i, i, 1, dim(a, 2), j, j) + x[i, j]), data),
     list(base = quote(x[i, j]),

--- a/tests/testthat/test-opt.R
+++ b/tests/testthat/test-opt.R
@@ -98,3 +98,108 @@ test_that("cope with adding zeros", {
     static_eval(quote(0 * x + 1 * 0)),
     0)
 })
+
+
+test_that("2d partial sum indexing correct", {
+  d <- c(7, 13)
+  m <- array(runif(prod(d)), d)
+
+  expected <- list(
+    "10" = rowSums(m),  # sum(m[i, ])
+    "01" = colSums(m))  # sum(m[, i])
+
+  info <- list(rank = 2, dimnames = list(dim = d))
+  i <- seq_along(m) - 1L
+
+  idx <- lapply(names(expected), function(key)
+    eval(array_sum_lhs_index(key, info)) + 1L)
+
+  ## What we need to do here is loop over the rhs and collect our answer:
+  f <- function(idx, m) {
+    res <- numeric(max(idx))
+    for (i in seq_along(m)) {
+      j <- idx[[i]]
+      res[[j]] <- res[[j]] + m[[i]]
+    }
+    res
+  }
+
+  res <- set_names(lapply(idx, f, m), names(expected))
+  expect_equal(res, expected)
+})
+
+
+test_that("3d partial sum indexing correct", {
+  d <- c(5, 7, 13)
+  m <- array(runif(prod(d)), d)
+
+  expected <- list(
+    "100" = apply(m, 1, sum),          # sum(x[i, , ])
+    "010" = apply(m, 2, sum),          # sum(x[, i, ])
+    "001" = apply(m, 3, sum),          # sum(x[, , i])
+    "120" = c(apply(m, 1:2, sum)),     # sum(a[i, j, ])
+    "102" = c(apply(m, c(1, 3), sum)), # sum(a[i, , j])
+    "012" = c(apply(m, 2:3, sum)))     # sum(a[, i, j])
+
+  info <- list(rank = 3, dimnames = list(dim = d, mult = cumprod(d)))
+  i <- seq_along(m) - 1L
+
+  idx <- lapply(names(expected), function(key)
+    eval(array_sum_lhs_index(key, info)) + 1L)
+
+  ## What we need to do here is loop over the rhs and collect our answer:
+  f <- function(idx, m) {
+    res <- numeric(max(idx))
+    for (i in seq_along(m)) {
+      j <- idx[[i]]
+      res[[j]] <- res[[j]] + m[[i]]
+    }
+    res
+  }
+
+  res <- set_names(lapply(idx, f, m), names(expected))
+  expect_equal(res, expected)
+})
+
+
+test_that("4d partial sum indexing correct", {
+  d <- c(3, 5, 7, 13)
+  m <- array(runif(prod(d)), d)
+
+  expected <- list(
+    "1000" = apply(m, 1, sum),             # sum(x[i, , , ])
+    "0100" = apply(m, 2, sum),             # sum(x[, i, , ])
+    "0010" = apply(m, 3, sum),             # sum(x[, , i, ])
+    "0001" = apply(m, 4, sum),             # sum(x[, , , i])
+    "1200" = c(apply(m, 1:2, sum)),        # sum(a[i, j, , ])
+    "1020" = c(apply(m, c(1, 3), sum)),    # sum(a[i, , j, ])
+    "1002" = c(apply(m, c(1, 4), sum)),    # sum(a[i, , , j])
+    "1002" = c(apply(m, c(1, 4), sum)),    # sum(a[i, , , j])
+    "0120" = c(apply(m, c(2, 3), sum)),    # sum(a[, i, j, ])
+    "0102" = c(apply(m, c(2, 4), sum)),    # sum(a[, i, , j])
+    "0012" = c(apply(m, c(3, 4), sum)),    # sum(a[, , i, j])
+    "1230" = c(apply(m, c(1, 2, 3), sum)), # sum(a[i, j, k, ])
+    "1203" = c(apply(m, c(1, 2, 4), sum)), # sum(a[i, j, , k])
+    "1023" = c(apply(m, c(1, 3, 4), sum)), # sum(a[i, , j, k])
+    "0123" = c(apply(m, c(2, 3, 4), sum))) # sum(a[, i, j, k])
+  ## 15 combinations...
+
+  info <- list(rank = 4, dimnames = list(dim = d, mult = cumprod(d)))
+  i <- seq_along(m) - 1L
+
+  idx <- lapply(names(expected), function(key)
+    eval(array_sum_lhs_index(key, info)) + 1L)
+
+  ## What we need to do here is loop over the rhs and collect our answer:
+  f <- function(idx, m) {
+    res <- numeric(max(idx))
+    for (i in seq_along(m)) {
+      j <- idx[[i]]
+      res[[j]] <- res[[j]] + m[[i]]
+    }
+    res
+  }
+
+  res <- set_names(lapply(idx, f, m), names(expected))
+  expect_equal(res, expected)
+})


### PR DESCRIPTION
This PR adds support for an alternative way of writing out partial sums (i.e., creating a lower dimensional tensor from a higher dimensional one by summing over some dimensions).

Currently supports expressions that can be factorised as addition of a series of terms which may or may not include partial sums.

- [ ] Implement support for subtraction
- [ ] Implement R code generation (?)
- [ ] Test for unary minus
- [ ] Test for impossible sums (just add parens, incomplete sums)
- [ ] Are our variable dependencies ok?

Fixes #235