### PR TITLE
Disallow named args in calls

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.3.1
+Version: 1.3.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -1505,6 +1505,11 @@ ir_parse_expr_rhs_check_usage <- function(rhs, line, source) {
           }
         }
       }
+
+      if (!is.null(names(x))) {
+        throw("Named argument calls not supported in odin")
+      }
+
       lapply(as.list(x[-1L]), check_usage)
     }
   }

--- a/tests/testthat/test-parse2-general.R
+++ b/tests/testthat/test-parse2-general.R
@@ -840,3 +840,14 @@ test_that("can't use C identifier", {
     }),
     "Reserved name 'int' for lhs")
 })
+
+
+test_that("Can't use named args", {
+  expect_error(
+    odin_parse({
+      update(x) <- rbinom(1, prob = 0.5)
+      initial(x) <- 1
+    }),
+    "Named argument calls not supported in odin",
+    fixed = TRUE)
+})


### PR DESCRIPTION
As noticed by @AmyDighe, we confusingly allow named args to calls. This PR throws an error if the user adds one. Turns out that the creates JSON was invalid anyway...