### PR TITLE
Nicer processing of parentheses in filenames

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.3.2
+Version: 1.3.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin 1.3.3
+
+* More gracefully cope with filenames containing parentheses
+
 # odin 1.3.0
 
 * Added JavaScript support, importing code previously in [`odin.js`](https://github.com/mrc-ide/odin.js/). Models with delays are not supported (mrc-1624)

--- a/R/odin_preprocess.R
+++ b/R/odin_preprocess.R
@@ -75,7 +75,7 @@ odin_preprocess_detect <- function(x, type = NULL) {
     } else if (file.exists(x)) {
       as <- "file"
     } else {
-      stop("'x' looks like a filename, but file does not exist")
+      stop(sprintf("'%s' looks like a filename, but file does not exist", x))
     }
   } else {
     stop("Invalid type for 'x'")

--- a/R/odin_preprocess.R
+++ b/R/odin_preprocess.R
@@ -23,7 +23,7 @@ odin_preprocess <- function(x, type = NULL) {
     base <- gsub("\\s*\\(\\d+\\)", "", base)
     ## But if we do get them after that we should remove them, along
     ## with any other punctuation
-    base <- chartr("- ()", "____", base)
+    base <- gsub("[-.() ]", "_", base)
     base <- gsub("_$", "", gsub("_{2,}", "_", base))
   } else {
     file <- NULL

--- a/R/odin_preprocess.R
+++ b/R/odin_preprocess.R
@@ -18,7 +18,13 @@ odin_preprocess <- function(x, type = NULL) {
     file <- x
     root <- normalizePath(dirname(x))
     path <- c(root, normalizePath(getwd()))
-    base <- chartr("- ", "__", tools::file_path_sans_ext(basename(file)))
+    base <- tools::file_path_sans_ext(basename(file))
+    ## Most of the time we get parentheses it will be download errors
+    base <- gsub("\\s*\\(\\d+\\)", "", base)
+    ## But if we do get them after that we should remove them, along
+    ## with any other punctuation
+    base <- chartr("- ()", "____", base)
+    base <- gsub("_$", "", gsub("_{2,}", "_", base))
   } else {
     file <- NULL
     path <- getwd()
@@ -64,7 +70,7 @@ odin_preprocess_detect <- function(x, type = NULL) {
         }
       }
       as <- type
-    } else if (length(x) != 1L || grepl("([\n;=()]|<-)", x)) {
+    } else if (length(x) != 1L || grepl("([\n;=]|<-)", x)) {
       as <- "text"
     } else if (file.exists(x)) {
       as <- "file"

--- a/tests/testthat/test-preprocess.R
+++ b/tests/testthat/test-preprocess.R
@@ -71,10 +71,12 @@ test_that("sanitise filenames", {
   path_spaces <- file.path(path, "path with spaces.R")
   path_parens1 <- file.path(path, "path_with_parens (1).R")
   path_parens2 <- file.path(path, "path_with_parens (a).R")
+  path_dots <- file.path(path, "path_with.dots.R")
   writeLines(code, path_hyphens)
   writeLines(code, path_spaces)
   writeLines(code, path_parens1)
   writeLines(code, path_parens2)
+  writeLines(code, path_dots)
 
   expect_equal(odin_preprocess(path_hyphens)$base,
                "path_with_hyphens")
@@ -84,4 +86,6 @@ test_that("sanitise filenames", {
                "path_with_parens")
   expect_equal(odin_preprocess(path_parens2)$base,
                "path_with_parens_a")
+  expect_equal(odin_preprocess(path_dots)$base,
+               "path_with_dots")
 })

--- a/tests/testthat/test-preprocess.R
+++ b/tests/testthat/test-preprocess.R
@@ -35,7 +35,9 @@ test_that("type detection avoids unlikely filenames", {
   expect_error(odin_preprocess_detect("x"), "looks like a filename")
   expect_equal(odin_preprocess_detect("x <- y"), "text")
   expect_equal(odin_preprocess_detect("x = y"), "text")
-  expect_equal(odin_preprocess_detect("deriv(x)"), "text")
+  ## Note that we do allow 'deriv(x)' as a sort of filename here,
+  ## perhaps not ideal, but it feels unlikely.
+  expect_equal(odin_preprocess_detect("deriv(x) = 1"), "text")
 })
 
 

--- a/tests/testthat/test-preprocess.R
+++ b/tests/testthat/test-preprocess.R
@@ -69,11 +69,19 @@ test_that("sanitise filenames", {
 
   path_hyphens <- file.path(path, "path-with-hyphens.R")
   path_spaces <- file.path(path, "path with spaces.R")
+  path_parens1 <- file.path(path, "path_with_parens (1).R")
+  path_parens2 <- file.path(path, "path_with_parens (a).R")
   writeLines(code, path_hyphens)
   writeLines(code, path_spaces)
+  writeLines(code, path_parens1)
+  writeLines(code, path_parens2)
 
   expect_equal(odin_preprocess(path_hyphens)$base,
                "path_with_hyphens")
   expect_equal(odin_preprocess(path_spaces)$base,
                "path_with_spaces")
+  expect_equal(odin_preprocess(path_parens1)$base,
+               "path_with_parens")
+  expect_equal(odin_preprocess(path_parens2)$base,
+               "path_with_parens_a")
 })

--- a/tests/testthat/test-preprocess.R
+++ b/tests/testthat/test-preprocess.R
@@ -21,6 +21,8 @@ test_that("text", {
 
   expect_error(odin_preprocess(tempfile()),
                "looks like a filename, but file does not exist")
+  expect_error(odin_preprocess("somefile.R"),
+               "'somefile.R' looks like a filename, but file does not exist")
 
   expect_error(odin_preprocess(1L), "Invalid type")
   expect_error(odin_preprocess(pi), "Invalid type")


### PR DESCRIPTION
This deals with the pathological/adversarial filenames in  https://github.com/mrc-ide/dust/pull/359#issuecomment-1011405080

* We allow parens now - previously they were not recognised as potential filenames and then we tried to parse them as code (if forcing filenames then we generated invalid code). We now create a basename that is reasonably sensible. This is not uncommon as `model (1).R` will be created by re-downloading a file.
* We allow periods within a filename (e.g., `model.txt.R`); the dots were previously not sanitised
* We report better if the file cannot be found (previously the error was `'x' looks like a filename, ...` which does not help the user)

```
> odin::odin("no file here.R")
Loading required namespace: pkgbuild
Error in odin_preprocess_detect(x, type) : 
  'no file here.R' looks like a filename, but file does not exist
```