### PR TITLE
Allow delays from js code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.3.5
+Version: 1.3.6
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -129,7 +129,6 @@ generate_js_core_output <- function(eqs, dat, rewrite) {
 
   args <- c(dat$meta$time, dat$meta$state,
             if (dat$features$has_delay) "solution")
-  browser()
   js_function(args, body)
 }
 

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -8,7 +8,7 @@ generate_js <- function(ir, options) {
   features <- vlapply(dat$features, identity)
   ## Disabling for now: has_interpolate, discrete, has_stochastic
   supported <- c("initial_time_dependent", "has_array", "has_user",
-                 "has_output")
+                 "has_output", "has_delay")
   unsupported <- setdiff(names(features)[features], supported)
   if (length(unsupported) > 0L) {
     stop("Using unsupported features: ",

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -91,7 +91,8 @@ generate_js_core_deriv <- function(eqs, dat, rewrite) {
 
   body <- js_flatten_eqs(c(internal, unpack, eqs[equations]))
 
-  args <- c(dat$meta$time, dat$meta$state, dat$meta$result)
+  args <- c(dat$meta$time, dat$meta$state, dat$meta$result,
+            if (dat$features$has_delay) "solution")
   js_function(args, body)
 }
 
@@ -126,7 +127,9 @@ generate_js_core_output <- function(eqs, dat, rewrite) {
   ret <- sprintf("return %s;", dat$meta$output)
   body <- js_flatten_eqs(c(internal, alloc, unpack, eqs[equations], ret))
 
-  args <- c(dat$meta$time, dat$meta$state)
+  args <- c(dat$meta$time, dat$meta$state,
+            if (dat$features$has_delay) "solution")
+  browser()
   js_function(args, body)
 }
 

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -60,6 +60,9 @@ generate_js_core_create <- function(eqs, dat, rewrite) {
   body$add("var %s = this.%s;", dat$meta$internal, dat$meta$internal)
   body$add(js_flatten_eqs(eqs[dat$components$create$equations]))
   body$add("this.setUser(%s, unusedUserAction);", dat$meta$user)
+  if (dat$features$has_delay && !dat$features$discrete) {
+    body$add("this.%s = NaN;", rewrite(dat$meta$initial_time))
+  }
   args <- c("base", dat$meta$user, "unusedUserAction")
   js_function(args, body$get(), "constructor")
 }
@@ -134,9 +137,13 @@ generate_js_core_output <- function(eqs, dat, rewrite) {
 
 
 generate_js_core_run <- function(eqs, dat, rewrite) {
-  body <- "return this.base.run(tStart, tEnd, y0, control, this, Dopri);"
-  args <- c("tStart", "tEnd", "y0", "control", "Dopri")
-  js_function(args, body)
+  body <- collector()
+  if (dat$features$has_delay && !dat$features$discrete) {
+    body$add("this.%s = tStart;", rewrite(dat$meta$initial_time))
+  }
+  body$add("return this.base.run(tStart, tEnd, y0, control, this, dopri);")
+  args <- c("tStart", "tEnd", "y0", "control", "dopri")
+  js_function(args, body$get())
 }
 
 

--- a/R/generate_js_equation.R
+++ b/R/generate_js_equation.R
@@ -175,12 +175,7 @@ generate_js_equation_array_lhs <- function(eq, data_info, dat, rewrite) {
   if (eq$type == "expression_array") {
     index <- vcapply(eq$rhs[[1]]$index, "[[", "index")
   } else {
-    ## This is here to support delays, which are not yet supported.
-    ## This *shoul* work but leaving in an assertion so that I
-    ## remember to double check it and remove the "no coverage"
-    ## marker.
-    stop("check for delays") # nocov
-    index <- lapply(eq$rhs$index, "[[", "index") # nocov
+    index <- lapply(eq$rhs$index, "[[", "index")
   }
   location <- data_info$location
 

--- a/R/generate_js_equation.R
+++ b/R/generate_js_equation.R
@@ -232,9 +232,12 @@ generate_js_equation_array_rhs <- function(value, index, lhs, rewrite) {
 generate_js_equation_delay_index <- function(eq, data_info, dat, rewrite) {
   delay <- dat$equations[[eq$delay]]$delay
   lhs <- rewrite(eq$lhs)
+  state <- rewrite(delay$state)
 
-  alloc <- sprintf("%s = this.base.zeros(%s)",
-                   lhs, rewrite(delay$variables$length))
+  alloc <- c(sprintf_safe("%s = this.base.zeros(%s)",
+                          lhs, rewrite(delay$variables$length)),
+             sprintf_safe("%s = this.base.zeros(%s)",
+                          state, rewrite(delay$variables$length)))
 
   index1 <- function(v) {
     d <- dat$data$elements[[v$name]]
@@ -284,7 +287,7 @@ generate_js_equation_delay_continuous <- function(eq, data_info, dat, rewrite) {
   ## _everything_ but will not work generally.
   unpack_vars <- js_flatten_eqs(lapply(
     names(delay$variables$contents), js_unpack_variable, dat, state, rewrite))
-  unpack_vars <- sub("^var\\s+", "", unpack_vars)
+  unpack_vars <- sub("^(var|const)\\s+", "", unpack_vars)
 
   eqs_src <- ir_substitute(dat$equations[delay$equations], delay$substitutions)
   eqs <- js_flatten_eqs(lapply(eqs_src, generate_js_equation, dat, rewrite))

--- a/R/generate_js_equation.R
+++ b/R/generate_js_equation.R
@@ -234,7 +234,7 @@ generate_js_equation_delay_index <- function(eq, data_info, dat, rewrite) {
              sprintf_safe("%s = this.base.zeros(%s)",
                           state, rewrite(delay$variables$length)))
 
-  index1 <- function(v) {
+  generate_index <- function(v) {
     d <- dat$data$elements[[v$name]]
     offset <- dat$data$variable$contents[[v$name]]$offset
     if (d$rank == 0L) {
@@ -248,7 +248,7 @@ generate_js_equation_delay_index <- function(eq, data_info, dat, rewrite) {
         "}")
     }
   }
-  index <- unname(lapply(delay$variables$contents, index1))
+  index <- unname(lapply(delay$variables$contents, generate_index))
   c(alloc, index)
 }
 
@@ -280,11 +280,6 @@ generate_js_equation_delay_continuous <- function(eq, data_info, dat, rewrite) {
   eqs_src <- ir_substitute(dat$equations[delay$equations], delay$substitutions)
   eqs <- js_flatten_eqs(lapply(eqs_src, generate_js_equation, dat, rewrite))
 
-  unpack_initial1 <- function(x) {
-    d <- dat$data$elements[[x$name]]
-    sprintf_safe("let %s = %s;", x$name, rewrite(x$initial))
-  }
-
   rhs_expr <- ir_substitute_sexpr(eq$rhs$value, delay$substitutions)
   if (data_info$rank == 0L) {
     lhs <- rewrite(eq$lhs)
@@ -295,11 +290,7 @@ generate_js_equation_delay_continuous <- function(eq, data_info, dat, rewrite) {
   }
 
   needs_variables <- length(delay$variables$contents) > 0L
-
   if (needs_variables) {
-    unpack_initial <-
-      lapply(dat$data$variable$contents[names(delay$variables$contents)],
-             unpack_initial1)
     unpack <- c(lookup_vars, unpack_vars)
   } else {
     unpack <- NULL

--- a/R/generate_js_equation.R
+++ b/R/generate_js_equation.R
@@ -281,13 +281,9 @@ generate_js_equation_delay_continuous <- function(eq, data_info, dat, rewrite) {
     "this.base.delay(%s, %s, %s, %s);",
     solution, time, index, state)
 
-  ## TODO: Looks like this needs work after all, because we need to
-  ## override the offset and because we won't want the 'var' at the
-  ## front. The below will work for now, because we access
-  ## _everything_ but will not work generally.
   unpack_vars <- js_flatten_eqs(lapply(
-    names(delay$variables$contents), js_unpack_variable, dat, state, rewrite))
-  unpack_vars <- sub("^(var|const)\\s+", "", unpack_vars)
+    delay$variables$contents, js_unpack_variable_delay,
+    dat$data$elements, state, rewrite))
 
   eqs_src <- ir_substitute(dat$equations[delay$equations], delay$substitutions)
   eqs <- js_flatten_eqs(lapply(eqs_src, generate_js_equation, dat, rewrite))

--- a/R/generate_js_util.R
+++ b/R/generate_js_util.R
@@ -36,7 +36,7 @@ js_extract_variable <- function(x, data_elements, state, rewrite) {
 js_unpack_variable <- function(name, dat, state, rewrite) {
   x <- dat$data$variable$contents[[name]]
   rhs <- js_extract_variable(x, dat$data$elements, state, rewrite)
-  sprintf("var %s = %s;", x$name, rhs)
+  sprintf("const %s = %s;", x$name, rhs)
 }
 
 
@@ -72,5 +72,19 @@ js_fold_call <- function(fn, args) {
     args[[1L]]
   } else {
     sprintf("%s(%s, %s)", fn, args[[1L]], js_fold_call(fn, args[-1]))
+  }
+}
+
+js_expr_if <- function(condition, a, b = NULL) {
+  if (is.null(b)) {
+    c(sprintf_safe("if (%s) {", condition),
+      paste0("  ", js_flatten_eqs(a)),
+      "}")
+  } else {
+    c(sprintf_safe("if (%s) {", condition),
+      paste0("  ", js_flatten_eqs(a)),
+      "} else {",
+      paste0("  ", js_flatten_eqs(b)),
+      "}")
   }
 }

--- a/R/generate_js_util.R
+++ b/R/generate_js_util.R
@@ -40,6 +40,12 @@ js_unpack_variable <- function(name, dat, state, rewrite) {
 }
 
 
+js_unpack_variable_delay <- function(x, data_elements, state, rewrite) {
+  rhs <- js_extract_variable(x, data_elements, state, rewrite)
+  sprintf("%s = %s;", x$name, rhs)
+}
+
+
 js_array_access <- function(target, index, data, meta) {
   mult <- data$elements[[target]]$dimnames$mult
 

--- a/R/generate_js_util.R
+++ b/R/generate_js_util.R
@@ -81,16 +81,10 @@ js_fold_call <- function(fn, args) {
   }
 }
 
-js_expr_if <- function(condition, a, b = NULL) {
-  if (is.null(b)) {
-    c(sprintf_safe("if (%s) {", condition),
-      paste0("  ", js_flatten_eqs(a)),
-      "}")
-  } else {
-    c(sprintf_safe("if (%s) {", condition),
-      paste0("  ", js_flatten_eqs(a)),
-      "} else {",
-      paste0("  ", js_flatten_eqs(b)),
-      "}")
-  }
+js_expr_if <- function(condition, a, b) {
+  c(sprintf_safe("if (%s) {", condition),
+    paste0("  ", js_flatten_eqs(a)),
+    "} else {",
+    paste0("  ", js_flatten_eqs(b)),
+    "}")
 }

--- a/R/generate_js_util.R
+++ b/R/generate_js_util.R
@@ -42,7 +42,7 @@ js_unpack_variable <- function(name, dat, state, rewrite) {
 
 js_unpack_variable_delay <- function(x, data_elements, state, rewrite) {
   rhs <- js_extract_variable(x, data_elements, state, rewrite)
-  sprintf("%s = %s;", x$name, rhs)
+  sprintf("const %s = %s;", x$name, rhs)
 }
 
 

--- a/R/js.R
+++ b/R/js.R
@@ -17,6 +17,7 @@ odin_js_wrapper_object <- function(res) {
   context$eval(paste(res$code, collapse = "\n"))
 
   is_discrete <- res$features$discrete
+  is_continuous_delay <- res$features$has_delay && !is_discrete
   private <- NULL
 
   ret <- R6::R6Class(
@@ -114,6 +115,10 @@ odin_js_wrapper_object <- function(res) {
           if (length(d) > 1) {
             dim(ret[[i]]) <- d
           }
+        }
+        if (is_continuous_delay && is.null(ret$initial_t)) {
+          ## NaN serialises to NULL, which is not quite what we want
+          ret$initial_t <- NA_real_
         }
         ret
       },

--- a/R/js.R
+++ b/R/js.R
@@ -164,6 +164,10 @@ odin_js_wrapper_object <- function(res) {
         y
       },
 
+      code = function() {
+        res$code
+      },
+
       engine = function() {
         "js"
       },

--- a/inst/js/dopri.js
+++ b/inst/js/dopri.js
@@ -89,8 +89,8 @@ var DDE = /** @class */ (function (_super) {
         return _this;
     }
     DDE.prototype.initialise = function (t, y) {
-        _super.prototype.initialise.call(this, t, y);
         this._y0 = y;
+        _super.prototype.initialise.call(this, t, y);
         return this;
     };
     DDE.prototype._interpolate = function (t) {

--- a/inst/js/support.js
+++ b/inst/js/support.js
@@ -94,7 +94,7 @@ class OdinBase {
             if (min !== null && value < min) {
                 throw Error("Expected '" + name + "' to be at least " + min);
             }
-            if (max !== null && value > min) {
+            if (max !== null && value > m)x) {
                 throw Error("Expected '" + name + "' to be at most " + max);
             }
             if (isInteger && !OdinBase.numberIsInteger(value)) {

--- a/inst/js/support.js
+++ b/inst/js/support.js
@@ -94,7 +94,7 @@ class OdinBase {
             if (min !== null && value < min) {
                 throw Error("Expected '" + name + "' to be at least " + min);
             }
-            if (max !== null && value > m)x) {
+            if (max !== null && value > max) {
                 throw Error("Expected '" + name + "' to be at most " + max);
             }
             if (isInteger && !OdinBase.numberIsInteger(value)) {

--- a/inst/js/support.js
+++ b/inst/js/support.js
@@ -1,6 +1,6 @@
 "use strict";
 
-function wodinRunner(Dopri, Model, pars, tStart, tEnd, control) {
+function wodinRunner(dopri, Model, pars, tStart, tEnd, control) {
     const grid = function(from, to, len) {
         const dx = (to - from) / (len - 1);
         const x = [];
@@ -12,7 +12,7 @@ function wodinRunner(Dopri, Model, pars, tStart, tEnd, control) {
 
     const model = new Model(OdinBase, pars, "error");
     const y0 = null; // Always use model-provide initial conditions
-    const result = model.run(tStart, tEnd, y0, control, Dopri);
+    const result = model.run(tStart, tEnd, y0, control, dopri);
     const solution = result.solution;
     const names = result.names;
     return function(t0, t1, nPoints) {
@@ -24,6 +24,16 @@ function wodinRunner(Dopri, Model, pars, tStart, tEnd, control) {
 }
 
 class OdinBase {
+    static delay(solution, t, index, state) {
+        // Later, we'll update dopri.js to allow passing index here,
+        // which will make this more efficient. However, no change to
+        // the external interface will be neeed.
+        var y = solution(t);
+        for (var i = 0; i < index.length; ++i) {
+            state[i] = y[index[i]];
+        }
+    }
+
     static isMissing(x) {
         return x === undefined || x === null ||
             (typeof x === "number" && isNaN(x));
@@ -267,16 +277,37 @@ class OdinBase {
         return OdinBase.flatten(rest, result)
     }
 
-    static run(tStart, tEnd, y0, control, model, Dopri) {
+    // NOTE: dopri here, not Dopri - breaking wodin change
+    static run(tStart, tEnd, y0, control, model, dopri) {
         if (y0 === null) {
             y0 = model.initial(tStart);
         }
-        const rhs = function(t, y, dydt) {
-            model.rhs(t, y, dydt);
+        // TODO: All this logic could be easily put into a function or
+        // methods within the dopri package. Something like
+        // `createSolver` seems sensible?
+        const hasDelay = model.rhs.length === 4;
+        const hasOutput = typeof model.output === "function";
+        let rhs;
+        let output = null;
+        let Solver;
+        if (hasDelay) {
+            Solver = dopri.DDE;
+            rhs = function(t, y, dydt, solution) {
+                model.rhs(t, y, dydt, solution);
+            }
+            if (hasOutput) {
+                output = ((t, y, solution) => model.output(t, y, solution));
+            }
+        } else {
+            Solver = dopri.Dopri;
+            rhs = function(t, y, dydt) {
+                model.rhs(t, y, dydt);
+            }
+            if (hasOutput) {
+                output = ((t, y) => model.output(t, y));
+            }
         }
-        const output = typeof model.output === "function" ?
-              ((t, y) => model.output(t, y)) : null;
-        const solver = new Dopri(rhs, y0.length, control, output);
+        const solver = new Solver(rhs, y0.length, control, output);
         solver.initialise(tStart, y0);
         const solution = solver.run(tEnd);
         const names = model.metadata.ynames.slice(1);
@@ -479,5 +510,4 @@ class OdinBase {
         }
         return tot;
     }
-
 }

--- a/inst/js/test.js
+++ b/inst/js/test.js
@@ -1,4 +1,4 @@
 function call_odin_bundle(Odin, pars, tStart, tEnd, nPoints, control) {
-    var solution = wodinRunner(dopri.Dopri, Odin, pars, tStart, tEnd, control);
+    var solution = wodinRunner(dopri, Odin, pars, tStart, tEnd, control);
     return solution(tStart, tEnd, nPoints);
 }

--- a/inst/js/wrapper.js
+++ b/inst/js/wrapper.js
@@ -33,7 +33,8 @@ class OdinWrapper {
     run(t, y0, control) {
         const tStart = t[0];
         const tEnd = t[t.length - 1];
-        const result = this.model.run(tStart, tEnd, y0, control, dopri.Dopri);
+        // TODO: this is a small breaking change for wodin
+        const result = this.model.run(tStart, tEnd, y0, control, dopri);
         return {y: result.solution(t),
                 names: result.names,
                 statistics: result.statistics};

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,27 +1,99 @@
 {
     "name": "odin.js",
     "version": "1.0.0",
-    "lockfileVersion": 1,
+    "lockfileVersion": 2,
     "requires": true,
+    "packages": {
+        "": {
+            "name": "odin.js",
+            "version": "1.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "dopri": "^0.0.9",
+                "random": "^2.2.0"
+            }
+        },
+        "node_modules/babel-runtime": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
+            "dependencies": {
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
+            }
+        },
+        "node_modules/core-js": {
+            "version": "2.6.12",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+            "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+            "deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+            "hasInstallScript": true
+        },
+        "node_modules/dopri": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.9.tgz",
+            "integrity": "sha512-SseN+0BeV9ZhXHJlNOpPrXFNBGEjFS5h8X1xR3Ew4IvDvNz7lGyLYGOIVKcFT1kK8EpPjVhN6NroCKx+pWqe5g=="
+        },
+        "node_modules/ow": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/ow/-/ow-0.4.0.tgz",
+            "integrity": "sha512-kJNzxUgVd6EF5LoGs+s2/etJPwjfRDLXPTCfEgV8At77sRrV+PSFA8lcoW2HF15Qd455mIR2Stee/2MzDiFBDA==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/ow-lite": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/ow-lite/-/ow-lite-0.0.2.tgz",
+            "integrity": "sha512-5PorMvUhPJACq2HOX54idr9TkRKPhzXIEu7DlM1iiVQoKC4rR8FAJND3bkOOiyGOgq6Ve7vh32o8Pfimr7tM4Q==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/random": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/random/-/random-2.2.0.tgz",
+            "integrity": "sha512-4HBR4Xye4jJ41QBi6RfIaO1yKQpxVUZafQtdE6NvvjzirNlwWgsk3tkGLTbQtWUarF4ofZsUVEmWqB1TDQlkwA==",
+            "dependencies": {
+                "babel-runtime": "^6.26.0",
+                "ow": "^0.4.0",
+                "ow-lite": "^0.0.2",
+                "seedrandom": "^3.0.5"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/regenerator-runtime": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        },
+        "node_modules/seedrandom": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+            "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+        }
+    },
     "dependencies": {
         "babel-runtime": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
             "requires": {
                 "core-js": "^2.4.0",
                 "regenerator-runtime": "^0.11.0"
             }
         },
         "core-js": {
-            "version": "2.6.11",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-            "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+            "version": "2.6.12",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+            "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
         },
         "dopri": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.8.tgz",
-            "integrity": "sha512-KN5IOC8+Y3JLjhbxqy20rkBOnowHoEePz2DTDZ14ojYqw/uy6jyTgTykd1ZhCMzTYGo07Z4jskpqwAwq/gBNpw=="
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/dopri/-/dopri-0.0.9.tgz",
+            "integrity": "sha512-SseN+0BeV9ZhXHJlNOpPrXFNBGEjFS5h8X1xR3Ew4IvDvNz7lGyLYGOIVKcFT1kK8EpPjVhN6NroCKx+pWqe5g=="
         },
         "ow": {
             "version": "0.4.0",
@@ -31,7 +103,7 @@
         "ow-lite": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/ow-lite/-/ow-lite-0.0.2.tgz",
-            "integrity": "sha1-359QDmdAtlkKHpqWVzDUmo61l9E="
+            "integrity": "sha512-5PorMvUhPJACq2HOX54idr9TkRKPhzXIEu7DlM1iiVQoKC4rR8FAJND3bkOOiyGOgq6Ve7vh32o8Pfimr7tM4Q=="
         },
         "random": {
             "version": "2.2.0",

--- a/js/package.json
+++ b/js/package.json
@@ -17,7 +17,7 @@
         "url": "https://github.com/mrc-ide/odin.js/issues"
     },
     "dependencies": {
-        "dopri": "^0.0.8",
+        "dopri": "^0.0.9",
         "random": "^2.2.0"
     },
     "homepage": "https://github.com/mrc-ide/odin.js#readme"

--- a/tests/testthat/helper-odin.R
+++ b/tests/testthat/helper-odin.R
@@ -49,7 +49,7 @@ validate_ir <- function() {
 
 options(odin.verbose = FALSE,
         odin.validate = validate_ir(),
-        odin.target = NULL)
+        odin.target = "js")
 
 
 unload_dlls <- function() {

--- a/tests/testthat/helper-odin.R
+++ b/tests/testthat/helper-odin.R
@@ -49,7 +49,7 @@ validate_ir <- function() {
 
 options(odin.verbose = FALSE,
         odin.validate = validate_ir(),
-        odin.target = "c")
+        odin.target = NULL)
 
 
 unload_dlls <- function() {

--- a/tests/testthat/helper-odin.R
+++ b/tests/testthat/helper-odin.R
@@ -49,7 +49,7 @@ validate_ir <- function() {
 
 options(odin.verbose = FALSE,
         odin.validate = validate_ir(),
-        odin.target = "js")
+        odin.target = "c")
 
 
 unload_dlls <- function() {

--- a/tests/testthat/test-js.R
+++ b/tests/testthat/test-js.R
@@ -247,3 +247,15 @@ test_that("Can't include code into js models (yet)", {
   "config(include) is not yet supported with JavaScript",
   fixed = TRUE)
 })
+
+
+test_that("Can show generated code", {
+  skip_if_not_installed("V8")
+  gen <- odin({
+    deriv(y) <- 1
+    initial(y) <- 1
+  }, target = "js")
+  code <- gen$public_methods$code()
+  expect_type(code, "character")
+  expect_equal(code[[1]], "class odin {")
+})

--- a/tests/testthat/test-js.R
+++ b/tests/testthat/test-js.R
@@ -150,17 +150,6 @@ test_that("accept matrices directly if asked nicely", {
 })
 
 
-test_that("delay models are not supported", {
-  expect_error(
-    odin({
-      ylag <- delay(y, 10)
-      initial(y) <- 0.5
-      deriv(y) <- 0.2 * ylag * 1 / (1 + ylag^10) - 0.1 * y
-    }, target = "js"),
-    "Using unsupported features: 'has_delay'")
-})
-
-
 test_that("some R functions are not available", {
   expect_error(
     odin({

--- a/tests/testthat/test-run-delay-continuous.R
+++ b/tests/testthat/test-run-delay-continuous.R
@@ -1,7 +1,6 @@
 context("run: continuous delays")
 
 test_that_odin("mixed delay model", {
-  skip_for_target("js")
   ## I want a model where the components of a delay are an array and a
   ## scalar.  This is going to be a pretty common thing to have, and I
   ## think it will throw up a few corner cases that are worth keeping
@@ -71,7 +70,6 @@ test_that_odin("mixed delay model", {
 
 
 test_that_odin("use subset of variables", {
-  skip_for_target("js")
   gen <- odin({
     deriv(a) <- 1
     deriv(b) <- 2
@@ -92,7 +90,6 @@ test_that_odin("use subset of variables", {
 })
 
 test_that_odin("delay array storage", {
-  skip_for_target("js")
   gen <- odin({
     ## Exponential growth/decay of 'y'
     deriv(y[]) <- r[i] * y[i]
@@ -200,7 +197,6 @@ test_that_odin("3 arg delay with array", {
 ## This should also be done with a couple of scalars thrown in here
 ## too I think; they change things also.
 test_that_odin("delay index packing", {
-  skip_for_target("js")
   gen <- odin({
     deriv(a[]) <- i
     deriv(b[]) <- i
@@ -239,14 +235,14 @@ test_that_odin("delay index packing", {
 
   seq0 <- function(n) seq_len(n)
 
-  if (odin_target_name() == "c") {
+  if (odin_target_name() != "r") {
     expect_length(dat$delay_state_foo, dim_b + dim_c + dim_e)
   }
 
   delay_index_foo <- c(dim_a + seq0(dim_b),
                        offset_variable_c + seq0(dim_c),
                        offset_variable_e + seq0(dim_e))
-  if (odin_target_name() == "c") {
+  if (odin_target_name() != "r") {
     delay_index_foo <- delay_index_foo - 1L
   }
   expect_equal(dat$delay_index_foo, delay_index_foo)
@@ -263,7 +259,6 @@ test_that_odin("delay index packing", {
 
 
 test_that_odin("nontrivial time", {
-  skip_for_target("js")
   gen <- odin({
     ylag <- delay(y, 2 + 3)
     initial(y) <- 0.5
@@ -279,7 +274,6 @@ test_that_odin("nontrivial time", {
 
 
 test_that_odin("overlapping array storage", {
-  skip_for_target("js")
   gen <- odin({
     ## Exponential growth/decay of 'y'
     deriv(y[]) <- r[i] * y[i]
@@ -340,7 +334,6 @@ test_that_odin("overlapping array storage", {
 
 
 test_that_odin("delayed delays", {
-  skip_for_target("js")
   gen <- odin({
     deriv(y) <- y
     initial(y) <- 1
@@ -365,7 +358,6 @@ test_that_odin("delayed delays", {
 
 
 test_that_odin("compute derivative", {
-  skip_for_target("js")
   gen <- odin({
     deriv(a) <- sin(t)
     initial(a) <- -1

--- a/tests/testthat/test-run-delay-continuous.R
+++ b/tests/testthat/test-run-delay-continuous.R
@@ -358,6 +358,9 @@ test_that_odin("delayed delays", {
 
 
 test_that_odin("compute derivative", {
+  ## This is not supported for the js model, and really it's not a
+  ## very sensible thing to try and do with these models anyway.
+  skip_for_target("js")
   gen <- odin({
     deriv(a) <- sin(t)
     initial(a) <- -1

--- a/tests/testthat/test-run-delay-continuous.R
+++ b/tests/testthat/test-run-delay-continuous.R
@@ -142,7 +142,6 @@ test_that_odin("delay array storage", {
 })
 
 test_that_odin("3 arg delay", {
-  skip_for_target("js")
   gen <- odin({
     ylag <- delay(y, 3, 2) # lag time 3, default value 2
     initial(y) <- 0.5
@@ -166,7 +165,6 @@ test_that_odin("3 arg delay", {
 
 
 test_that_odin("3 arg delay with array", {
-  skip_for_target("js")
   gen <- odin({
     deriv(a[]) <- i
     initial(a[]) <- (i - 1) / 10
@@ -435,7 +433,6 @@ test_that_odin("compute derivative", {
 ## This triggered a crash in set_initial, due to invalid loading of
 ## array initial variable information
 test_that_odin("delay with array and provide input", {
-  skip_for_target("js")
   gen <- odin({
     ## Exponential growth/decay of 'y'
     deriv(y[]) <- r[i] * y[i]
@@ -480,7 +477,6 @@ test_that_odin("delay with array and provide input", {
 
 
 test_that_odin("set initial conditions in delay differential equation", {
-  skip_for_target("js")
   gen <- odin({
     ylag <- delay(y, 2 + 3)
     initial(y) <- 0.5
@@ -497,7 +493,6 @@ test_that_odin("set initial conditions in delay differential equation", {
 
 
 test_that_odin("can set/omit ynames", {
-  skip_for_target("js")
   gen <- odin({
     ylag <- delay(y, 2 + 3)
     initial(y) <- 0.5

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -69,7 +69,6 @@ test_that_odin("user variables on models with none", {
 })
 
 test_that_odin("non-numeric time", {
-  skip_for_target("js")
   ## Only an issue for delay models or models with time-dependent
   ## initial conditions.
   gen <- odin({
@@ -84,7 +83,6 @@ test_that_odin("non-numeric time", {
 })
 
 test_that_odin("delays and initial conditions", {
-  skip_for_target("js")
   gen <- odin({
     ylag <- delay(y, 10)
     initial(y) <- 0.5
@@ -113,6 +111,8 @@ test_that_odin("delays and initial conditions", {
   res4 <- mod$run(t + 3, 0.6)
 
   expect_equal(mod$contents()$initial_t, 3.0)
+  ## TODO: error here, nothing too alarming because we get the correct
+  ## answer at least for run
   expect_equal(mod$contents()$initial_y, 0.6)
   expect_false(isTRUE(all.equal(res4[, 2], res1[, 2])))
 })

--- a/tests/testthat/test-run-general.R
+++ b/tests/testthat/test-run-general.R
@@ -111,9 +111,10 @@ test_that_odin("delays and initial conditions", {
   res4 <- mod$run(t + 3, 0.6)
 
   expect_equal(mod$contents()$initial_t, 3.0)
-  ## TODO: error here, nothing too alarming because we get the correct
-  ## answer at least for run
-  expect_equal(mod$contents()$initial_y, 0.6)
+  ## NOTE: we don't save this for js models, because we never look it up later
+  if (mod$engine() != "js") {
+    expect_equal(mod$contents()$initial_y, 0.6)
+  }
   expect_false(isTRUE(all.equal(res4[, 2], res1[, 2])))
 })
 


### PR DESCRIPTION
This PR merges into #257 not master, and follows from #258, see https://github.com/mrc-ide/odin/compare/mrc-3180...mrc-3214 for a diff that covers just these changes

Quite a lot of small changes to make this work:
* save the initial time
* pass the solution to the rhs and output function
* new equations generated for `delay_index` (on parameter setup, stores an array of indices)
* new equations generated for `delay_continuous` - this is the bulk of the hard bit

~I've manually copied over the change from https://github.com/mrc-ide/dopri-js/pull/15 which is needed to fix DDE solutions~

There's a small breaking change for wodin - rather than passing `dopri.Dopri`, now pass `dopri` as for the delay differential equations we need to use `dopri.DDE` as the solver.

Gratifyingly, effects on the tests are minimal!