### PR TITLE
Start on support for mixed models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.3.4
+Version: 1.3.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/R/generate_c.R
+++ b/R/generate_c.R
@@ -24,6 +24,10 @@ generate_c_meta <- function(base, internal) {
 generate_c_code <- function(dat, options, package) {
   dat$meta$c <- generate_c_meta(dat$config$base, dat$meta$internal)
 
+  if (dat$features$mixed) {
+    stop("Models that mix deriv() and update() are not supported")
+  }
+
   if (dat$features$has_delay) {
     dat$data$elements[[dat$meta$c$use_dde]] <-
       list(name = dat$meta$c$use_dde,

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -1,6 +1,10 @@
 generate_js <- function(ir, options) {
   dat <- odin_ir_deserialise(ir)
 
+  if (dat$features$mixed) {
+    stop("Models that mix deriv() and update() are not supported")
+  }
+
   rewrite <- function(x) {
     generate_js_sexp(x, dat$data, dat$meta)
   }

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -6,7 +6,8 @@ generate_js <- function(ir, options) {
   }
 
   features <- vlapply(dat$features, identity)
-  supported <- c("initial_time_dependent", "has_array", "has_user",
+  supported <- c("continuous",
+                 "initial_time_dependent", "has_array", "has_user",
                  "has_output", "has_interpolate", "discrete", "has_stochastic")
   unsupported <- setdiff(names(features)[features], supported)
   if (length(unsupported) > 0L) {

--- a/R/generate_r.R
+++ b/R/generate_r.R
@@ -1,4 +1,8 @@
 generate_r <- function(dat, options) {
+  if (dat$features$mixed) {
+    stop("Models that mix deriv() and update() are not supported")
+  }
+
   if (dat$features$has_delay) {
     ## We're going to need an additional bit of internal data here,
     ## but this sits outside the core odin ir

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -506,19 +506,19 @@ ir_parse_components <- function(eqs, dependencies, variables, stage,
   eqs_initial <- intersect(eqs_time, v)
 
   if (common$mixed) {
-    stochastic_update <- names_if(vlapply(eqs, function(x)
+    update_stochastic <- names_if(vlapply(eqs, function(x)
       identical(x$lhs$special, "update")))
-    v <- unique(unlist(dependencies[stochastic_update], use.names = FALSE))
-    eqs_stochastic_update <- intersect(eqs_time, c(stochastic_update, v))
-    variables_stochastic_update <- intersect(variables, v)
+    v <- unique(unlist(dependencies[update_stochastic], use.names = FALSE))
+    eqs_update_stochastic <- intersect(eqs_time, c(update_stochastic, v))
+    variables_update_stochastic <- intersect(variables, v)
   } else {
-    eqs_stochastic_update <- character(0)
-    variables_stochastic_update <- character(0)
+    eqs_update_stochastic <- character(0)
+    variables_update_stochastic <- character(0)
   }
 
   type <- vcapply(eqs, "[[", "type")
   core <- unique(c(initial, rhs, output, eqs_initial, eqs_rhs, eqs_output,
-                   eqs_stochastic_update))
+                   eqs_update_stochastic))
 
   used_in_delay <- unlist(lapply(eqs[type == "delay_continuous"], function(x)
     x$delay$depends$variables), FALSE, FALSE)
@@ -535,8 +535,8 @@ ir_parse_components <- function(eqs, dependencies, variables, stage,
     user = list(variables = character(0), equations = eqs_user),
     initial = list(variables = character(0), equations = eqs_initial),
     rhs = list(variables = variables_rhs, equations = eqs_rhs),
-    stochastic_update = list(variables = variables_stochastic_update,
-                             equations = eqs_stochastic_update),
+    update_stochastic = list(variables = variables_update_stochastic,
+                             equations = eqs_update_stochastic),
     output = list(variables = variables_output, equations = eqs_output))
 }
 

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -214,7 +214,7 @@ ir_parse_find_variables <- function(eqs, common, source) {
   is_special <- vlapply(eqs, function(x) !is.null(x$lhs$special))
   special <- vcapply(eqs[is_special], function(x) x$lhs$special)
   name_data <- vcapply(eqs[is_special], function(x) x$lhs$name_data)
-  
+
   rhs_fun <- common$rhs
   rhs_fun_show <- paste0(rhs_fun, "()", collapse = " or ")
 
@@ -499,7 +499,7 @@ ir_parse_components <- function(eqs, dependencies, variables, stage,
 
   if (common$mixed) {
     MIXED <- names_if(vlapply(eqs, function(x)
-      identical(x$lhs$special, "update"))) 
+      identical(x$lhs$special, "update")))
     v <- unique(unlist(dependencies[MIXED], use.names = FALSE))
     eqs_MIXED <- intersect(eqs_time, c(MIXED, v))
     variables_MIXED <- intersect(variables, v)

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -12,9 +12,7 @@ ir_parse <- function(x, options, type = NULL) {
                             options$config_custom)
   features <- ir_parse_features(eqs, config, source)
 
-  ## TODO: lots in common here, can probably combine
   common <- ir_parse_common(features)
-  meta <- ir_parse_meta(features$continuous)
 
   variables <- ir_parse_find_variables(eqs, common, source)
 
@@ -53,6 +51,8 @@ ir_parse <- function(x, options, type = NULL) {
   }
 
   eqs <- eqs[order(names(eqs))]
+
+  meta <- ir_parse_meta(common)
 
   ## If we have arrays, then around this point we will also be
   ## generating a number of additional offset and dimension length
@@ -197,16 +197,15 @@ ir_parse_common <- function(features) {
 }
 
 
-ir_parse_meta <- function(continuous) {
-  time <- if (continuous) TIME else STEP
-  result <- if (continuous) DSTATEDT else STATE_NEXT
+ir_parse_meta <- function(common) {
+  result <- if (common$continuous) DSTATEDT else STATE_NEXT
   list(internal = INTERNAL,
        user = USER,
        state = STATE,
        result = result,
        output = OUTPUT,
-       time = time,
-       initial_time = initial_name(time))
+       time = common$time,
+       initial_time = initial_name(common$time))
 }
 
 

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -506,19 +506,19 @@ ir_parse_components <- function(eqs, dependencies, variables, stage,
   eqs_initial <- intersect(eqs_time, v)
 
   if (common$mixed) {
-    MIXED <- names_if(vlapply(eqs, function(x)
+    stochastic_update <- names_if(vlapply(eqs, function(x)
       identical(x$lhs$special, "update")))
-    v <- unique(unlist(dependencies[MIXED], use.names = FALSE))
-    eqs_MIXED <- intersect(eqs_time, c(MIXED, v))
-    variables_MIXED <- intersect(variables, v)
+    v <- unique(unlist(dependencies[stochastic_update], use.names = FALSE))
+    eqs_stochastic_update <- intersect(eqs_time, c(stochastic_update, v))
+    variables_stochastic_update <- intersect(variables, v)
   } else {
-    eqs_MIXED <- NULL
-    variables_MIXED <- NULL
+    eqs_stochastic_update <- character(0)
+    variables_stochastic_update <- character(0)
   }
 
   type <- vcapply(eqs, "[[", "type")
   core <- unique(c(initial, rhs, output, eqs_initial, eqs_rhs, eqs_output,
-                   eqs_MIXED))
+                   eqs_stochastic_update))
 
   used_in_delay <- unlist(lapply(eqs[type == "delay_continuous"], function(x)
     x$delay$depends$variables), FALSE, FALSE)
@@ -535,7 +535,8 @@ ir_parse_components <- function(eqs, dependencies, variables, stage,
     user = list(variables = character(0), equations = eqs_user),
     initial = list(variables = character(0), equations = eqs_initial),
     rhs = list(variables = variables_rhs, equations = eqs_rhs),
-    MIXED = list(variables = variables_MIXED, equations = eqs_MIXED),
+    stochastic_update = list(variables = variables_stochastic_update,
+                             equations = eqs_stochastic_update),
     output = list(variables = variables_output, equations = eqs_output))
 }
 

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -505,6 +505,7 @@ ir_parse_components <- function(eqs, dependencies, variables, stage,
     variables_MIXED <- intersect(variables, v)
   } else {
     eqs_MIXED <- NULL
+    variables_MIXED <- NULL
   }
 
   type <- vcapply(eqs, "[[", "type")

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -237,7 +237,7 @@ ir_parse_find_variables <- function(eqs, common, source) {
       msg$add("\tin initial() but not %s: %s",
               rhs_fun_show, paste(msg_vars, collapse = ", "))
     }
-    tmp <- eqs[is_var | is_initial]
+    tmp <- eqs[is_special][is_var | is_initial]
     ir_parse_error(sprintf(
       "%s and initial() must contain same set of equations:\n%s\n",
       rhs_fun_show, paste(msg$get(), collapse = "\n")),
@@ -254,7 +254,15 @@ ir_parse_find_variables <- function(eqs, common, source) {
   }
 
   if (common$mixed) {
-    ## TODO: test that nothing is updated in both
+    var_both <- intersect(name_data[special == "update"],
+                          name_data[special == "deriv"])
+    if (length(var_both) > 0) {
+      tmp <- eqs[is_special][name_data %in% var_both & !is_initial]
+      ir_parse_error(sprintf(
+        "Both update() and deriv() equations present for %s:",
+        paste(var_both, collapse = ", ")),
+        ir_parse_error_lines(tmp), source)
+    }
   }
 
   unique(unname(vars))

--- a/inst/schema.json
+++ b/inst/schema.json
@@ -738,7 +738,7 @@
                 "initial": { "$ref": "#/definitions/component" },
                 "rhs": { "$ref": "#/definitions/component" },
                 "output": { "$ref": "#/definitions/component" },
-                "stochastic_update": { "$ref": "#/definitions/component" }
+                "update_stochastic": { "$ref": "#/definitions/component" }
             },
             "required": ["create", "user", "initial", "rhs", "output"],
             "additionalProperties": false

--- a/inst/schema.json
+++ b/inst/schema.json
@@ -738,7 +738,7 @@
                 "initial": { "$ref": "#/definitions/component" },
                 "rhs": { "$ref": "#/definitions/component" },
                 "output": { "$ref": "#/definitions/component" },
-                "MIXED": {}
+                "stochastic_update": { "$ref": "#/definitions/component" }
             },
             "required": ["create", "user", "initial", "rhs", "output"],
             "additionalProperties": false

--- a/inst/schema.json
+++ b/inst/schema.json
@@ -190,7 +190,9 @@
         "features": {
             "type": "object",
             "properties": {
+                "continuous": { "type": "boolean" },
                 "discrete": { "type": "boolean" },
+                "mixed": { "type": "boolean" },
                 "has_array": { "type": "boolean" },
                 "has_output": { "type": "boolean" },
                 "has_user": { "type": "boolean" },
@@ -735,7 +737,8 @@
                 "user": { "$ref": "#/definitions/component" },
                 "initial": { "$ref": "#/definitions/component" },
                 "rhs": { "$ref": "#/definitions/component" },
-                "output": { "$ref": "#/definitions/component" }
+                "output": { "$ref": "#/definitions/component" },
+                "MIXED": {}
             },
             "required": ["create", "user", "initial", "rhs", "output"],
             "additionalProperties": false

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -149,4 +149,15 @@ test_that("compatibility layer passes to R6 class", {
 })
 
 
+test_that_odin("mixed models not supported by any odin target", {
+  expect_error(odin({
+    initial(x) <- 0
+    deriv(x) <- a
+    initial(a) <- 0
+    update(a) <- a + 1
+  }),
+  "Models that mix deriv() and update() are not supported",
+  fixed = TRUE)
+})
+
 unload_dlls()

--- a/tests/testthat/test-parse2-general.R
+++ b/tests/testthat/test-parse2-general.R
@@ -864,7 +864,7 @@ test_that("Can parse a simple mixed model", {
     dat$components$rhs,
     list(variables = "a", equations = "deriv_x"))
   expect_equal(
-    dat$components$stochastic_update,
+    dat$components$update_stochastic,
     list(variables = "a", equations = "update_a"))
 })
 

--- a/tests/testthat/test-parse2-general.R
+++ b/tests/testthat/test-parse2-general.R
@@ -864,7 +864,7 @@ test_that("Can parse a simple mixed model", {
     dat$components$rhs,
     list(variables = "a", equations = "deriv_x"))
   expect_equal(
-    dat$components$MIXED,
+    dat$components$stochastic_update,
     list(variables = "a", equations = "update_a"))
 })
 

--- a/tests/testthat/test-parse2-general.R
+++ b/tests/testthat/test-parse2-general.R
@@ -847,3 +847,23 @@ test_that("Can't use named args", {
     "Named argument calls not supported in odin",
     fixed = TRUE)
 })
+
+
+test_that("Can generate a mixed model", {
+  ir <- odin_parse({
+    initial(x) <- 0
+    deriv(x) <- a
+    initial(a) <- 0
+    update(a) <- a + 1
+  })
+  dat <- ir_deserialise(ir)
+  expect_true(dat$features$continuous)
+  expect_true(dat$features$discrete)
+  expect_true(dat$features$mixed)
+  expect_equal(
+    dat$components$rhs,
+    list(variables = "a", equations = "deriv_x"))
+  expect_equal(
+    dat$components$MIXED,
+    list(variables = "a", equations = "update_a"))
+})

--- a/tests/testthat/test-parse2-general.R
+++ b/tests/testthat/test-parse2-general.R
@@ -94,10 +94,6 @@ test_that("compatible rhs", {
   expect_error(odin_parse("update(y) = 1; initial(x) = 2"),
                "must contain same set of equations",
                class = "odin_error")
-
-  expect_error(odin_parse(
-    "deriv(y) = 1; update(z) = 1; initial(y) = 1; initial(z) = 1;"),
-    "Cannot mix deriv() and update()", fixed = TRUE, class = "odin_error")
 })
 
 

--- a/tests/testthat/test-parse2-general.R
+++ b/tests/testthat/test-parse2-general.R
@@ -849,7 +849,7 @@ test_that("Can't use named args", {
 })
 
 
-test_that("Can generate a mixed model", {
+test_that("Can parse a simple mixed model", {
   ir <- odin_parse({
     initial(x) <- 0
     deriv(x) <- a
@@ -866,4 +866,16 @@ test_that("Can generate a mixed model", {
   expect_equal(
     dat$components$MIXED,
     list(variables = "a", equations = "update_a"))
+})
+
+
+test_that("Prevent use of a variable in both deriv and update", {
+  expect_error(odin_parse({
+    initial(x) <- 0
+    v <- user()
+    deriv(x) <- a + v
+    update(x) <- a + 1 + v
+  }),
+  "Both update() and deriv() equations present for x",
+  fixed = TRUE)
 })


### PR DESCRIPTION
This is a pretty big conceptual change for odin, and hard to really test well in the package as we don't have a good mixed ode/stochastic model to push around (I would rather not have to try and write an SDE solver of course). So here I'm just implementing the metadata collection part as the final changes required in the IR are fairly small and easy enough to think about. We'll then drag this through odin.dust and once both are happy we can merge

Once merged, https://github.com/mrc-ide/odin.dust/pull/103 should be merged fairly shortly as otherwise we break compilation of odin dust models. That in turn requires https://github.com/mrc-ide/mode/pull/24 to be merged first, though nobody depends on that yet