### PR TITLE
Validate number of arguments passed to stochastic functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.3.5
+Version: 1.3.6
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -1502,7 +1502,9 @@ ir_parse_delay_continuous_graph <- function(eq, eqs, variables, source) {
 
 ir_parse_expr_rhs_check_usage <- function(rhs, line, source) {
   len <- c(FUNCTIONS,
-           setNames(FUNCTIONS[FUNCTIONS_RENAME], names(FUNCTIONS_RENAME)))
+           setNames(FUNCTIONS[FUNCTIONS_RENAME], names(FUNCTIONS_RENAME)),
+           FUNCTIONS_STOCHASTIC,
+           lapply(FUNCTIONS_INPLACE, "[[", "len"))
 
   throw <- function(...) {
     ir_parse_error(sprintf(...), line, source)

--- a/tests/testthat/test-parse2-general.R
+++ b/tests/testthat/test-parse2-general.R
@@ -879,3 +879,14 @@ test_that("Prevent use of a variable in both deriv and update", {
   "Both update() and deriv() equations present for x",
   fixed = TRUE)
 })
+
+
+test_that("Validate arguments to stochastic functions", {
+  ## Interestingly, this one does not either!
+  expect_error(
+    odin_parse({
+      initial(a) <- 0
+      update(a) <- a + rnorm(1)
+    }),
+    "Expected 2 arguments in rnorm call, but recieved 1")
+})


### PR DESCRIPTION
Noticed this while setting up tests for https://github.com/mrc-ide/odin.dust/pull/104 - the stochastic functions were excluded from the already-existing function argument checking. So previously this failed nastily:

```
odin::odin({
    initial(a) <- 0
    update(a) <- a + rnorm(1)
})
```

```
Loading required namespace: pkgbuild
Generating model in c
Re-compiling odinaf787418
─  installing *source* package ‘odinaf787418’ ...
   ** using staged installation
   ** libs
   gcc -I"/usr/share/R/include" -DNDEBUG   -g -Wall -Wextra -pedantic -Wmaybe-uninitialized -Wno-unused-parameter -Wno-cast-function-type -Wno-missing-field-initializers -O2   -fpic  -std=gnu17 -g -Wall -Wextra -pedantic -Wmaybe-uninitialized -Wno-unused-parameter -Wno-cast-function-type -Wno-missing-field-initializers -O2 -Werror=implicit-function-declaration -c odin.c -o odin.o
   odin.c: In function ‘odin_metadata’:
   odin.c:75:18: warning: unused variable ‘internal’ [-Wunused-variable]
      75 |   odin_internal *internal = odin_get_internal(internal_p, 1);
         |                  ^~~~~~~~
   odin.c: In function ‘odin_rhs’:
   odin.c:105:23: error: too few arguments to function ‘Rf_rnorm’
     105 |   state_next[0] = a + Rf_rnorm(1);
         |                       ^~~~~~~~
   In file included from odin.c:3:
   /usr/share/R/include/Rmath.h:333:16: note: declared here
     333 | #define rnorm  Rf_rnorm
         |                ^~~~~~~~
   /usr/share/R/include/Rmath.h:375:8: note: in expansion of macro ‘rnorm’
     375 | double rnorm(double, double);
         |        ^~~~~
   make: *** [/usr/lib/R/etc/Makeconf:168: odin.o] Error 1
   ERROR: compilation failed for package ‘odinaf787418’
─  removing ‘/tmp/Rtmp8P6Mxt/devtools_install_717577d54ce9/odinaf787418’
Error in `(function (command = NULL, args = character(), error_on_status = TRUE, …`:
! System command 'R' failed
---
Exit status: 1
Stdout & stderr (last 10 lines, see `$stderr` for more):
In file included from odin.c:3:
/usr/share/R/include/Rmath.h:333:16: note: declared here
  333 | #define rnorm  Rf_rnorm
      |                ^~~~~~~~
/usr/share/R/include/Rmath.h:375:8: note: in expansion of macro ‘rnorm’
  375 | double rnorm(double, double);
      |        ^~~~~
make: *** [/usr/lib/R/etc/Makeconf:168: odin.o] Error 1
ERROR: compilation failed for package ‘odinaf787418’
* removing ‘/tmp/Rtmp8P6Mxt/devtools_install_717577d54ce9/odinaf787418’
---
Type .Last.error to see the more details.
```

With this PR we now fail at parse:

```
Error: Expected 2 arguments in rnorm call, but recieved 1
	update(a) <- a + rnorm(1) # (line 2)
```