### PR TITLE
Fix lint

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,8 +1,7 @@
-linters: with_defaults(
+linters: linters_with_defaults(
     object_name_linter = NULL,
     object_length_linter = NULL,
     object_usage_linter = NULL,
-    todo_comment_linter = NULL,
     cyclocomp_linter = NULL
     )
-exclusions: list("tests/testthat.R")
+exclusions: list("tests/testthat.R", "inst/template/odin_c.R")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.4.0
+Version: 1.4.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -46,8 +46,9 @@ join_deps <- function(x) {
   stopifnot(is.list(x))
   x <- x[!vlapply(x, is.null)]
   ## This should never be triggered
-  ok <- vlapply(x, function(el)
-    identical(names(el), c("functions", "variables")))
+  ok <- vlapply(x, function(el) {
+    identical(names(el), c("functions", "variables"))
+  })
   stopifnot(all(ok))
   if (length(x) == 0L) {
     list(functions = character(0), variables = character(0))

--- a/R/generate_c_compiled.R
+++ b/R/generate_c_compiled.R
@@ -640,14 +640,16 @@ generate_c_compiled_metadata <- function(dat, rewrite) {
     ## TODO: we should generate out the the critical bits but that's
     ## another problem.  See the comments in
     ## support_check_interpolate_t
-    args_min <- c_fold_call("fmax", vcapply(dat$interpolate$min, function(x)
-      sprintf("%s[0]", rewrite(x))))
+    args_min <- c_fold_call("fmax", vcapply(dat$interpolate$min, function(x) {
+      sprintf("%s[0]", rewrite(x))
+    }))
     if (length(dat$interpolate$max) == 0) {
       args_max <- "R_PosInf"
     } else {
-      args_max <- c_fold_call("fmin", vcapply(dat$interpolate$max, function(x)
+      args_max <- c_fold_call("fmin", vcapply(dat$interpolate$max, function(x) {
         sprintf("%s[%s - 1]", rewrite(x),
-                rewrite(dat$data$elements[[x]]$dimnames$length))))
+                rewrite(dat$data$elements[[x]]$dimnames$length))
+      }))
     }
 
     body$add("SEXP interpolate_t = PROTECT(allocVector(VECSXP, 3));")
@@ -700,8 +702,9 @@ generate_c_compiled_library <- function(dat, is_package) {
   }
   if (dat$features$has_user && dat$features$has_array) {
     d <- dat$data$elements
-    user_arrays <- any(vlapply(dat$equations, function(x)
-      !is.null(x$user) && d[[x$name]]$rank > 0))
+    user_arrays <- any(vlapply(dat$equations, function(x) {
+      !is.null(x$user) && d[[x$name]]$rank > 0
+    }))
     if (user_arrays) {
       v <- c(v, "user_get_array_dim",
              "user_get_array", "user_get_array_check",
@@ -715,8 +718,8 @@ generate_c_compiled_library <- function(dat, is_package) {
     v <- c(v, "interpolate_check_y")
   }
 
-  used <- unique(unlist(lapply(dat$equations, function(x)
-    x$depends$functions), FALSE, FALSE))
+  used <- unique(unlist(lapply(dat$equations, function(x) x$depends$functions),
+                        FALSE, FALSE))
   if ("%%" %in% used) {
     v <- c(v, "fmodr")
   }
@@ -746,8 +749,9 @@ generate_c_compiled_library <- function(dat, is_package) {
       nms <- vcapply(extra, "[[", "name")
       extra_lib <- list(
         declarations = set_names(vcapply(extra, "[[", "declaration"), nms),
-        definitions = set_names(vcapply(extra, function(x)
-          paste0(x$definition, "\n", collapse = "")), nms))
+        definitions = set_names(vcapply(extra, function(x) {
+          paste0(x$definition, "\n", collapse = "")
+        }), nms))
       lib <- join_library(list(lib, extra_lib))
     }
   }

--- a/R/generate_c_equation.R
+++ b/R/generate_c_equation.R
@@ -80,8 +80,9 @@ generate_c_equation_inplace_rmhyper <- function(eq, lhs, data_info, dat,
 
 generate_c_equation_array <- function(eq, data_info, dat, rewrite) {
   lhs <- generate_c_equation_array_lhs(eq, data_info, dat, rewrite)
-  lapply(eq$rhs, function(x)
-    generate_c_equation_array_rhs(x$value, x$index, lhs, rewrite))
+  lapply(eq$rhs, function(x) {
+    generate_c_equation_array_rhs(x$value, x$index, lhs, rewrite)
+  })
 }
 
 
@@ -447,7 +448,7 @@ generate_c_equation_delay_discrete <- function(eq, data_info, dat, rewrite) {
     advance,
     sprintf_safe("double * %s;", tail),
     c_expr_if(time_check, data_initial, data_offset),
-    assign) -> ret
+    assign)
 }
 
 

--- a/R/generate_c_support.R
+++ b/R/generate_c_support.R
@@ -12,8 +12,9 @@ generate_c_support_sum <- function(rank) {
   ## here, though in general they are not needed as function scope
   ## avoids the worst of things.
   index <- INDEX[i]
-  mult <- vcapply(seq_len(rank), function(x)
-    array_dim_name("x", paste(seq_len(x - 1), collapse = "")))
+  mult <- vcapply(seq_len(rank), function(x) {
+    array_dim_name("x", paste(seq_len(x - 1), collapse = ""))
+  })
   counter <- vcapply(index, strrep, n = 2, USE.NAMES = FALSE)
 
   limits <- rbind(sprintf_safe("from_%s", index),

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -17,10 +17,11 @@ generate_js <- function(ir, options) {
   eqs <- generate_js_equations(dat, rewrite)
   core <- generate_js_core(eqs, dat, rewrite)
 
-  internal_dim_elements <- vlapply(dat$data$elements, function(x)
+  internal_dim_elements <- vlapply(dat$data$elements, function(x) {
     x$location == "internal" &&
     x$storage_type %in% c("double", "int", "bool") &&
-    x$rank > 1)
+    x$rank > 1
+  })
   internal_dim <- lapply(dat$data$elements[internal_dim_elements],
                          function(x) x$dimnames$dim)
 
@@ -203,26 +204,28 @@ generate_js_core_update_metadata <- function(eqs, dat, rewrite) {
   }
 
   if (dat$features$has_interpolate) {
-    args_min <- js_fold_call("Math.max",
-                             vcapply(dat$interpolate$min, function(x)
-                               sprintf("%s[0]", rewrite(x))))
+    args_min <- js_fold_call(
+      "Math.max",
+      vcapply(dat$interpolate$min, function(x) sprintf("%s[0]", rewrite(x))))
     if (length(dat$interpolate$max) == 0) {
       args_max <- "Infinity"
     } else {
       args_max <- js_fold_call(
         "Math.min",
-        vcapply(dat$interpolate$max, function(x)
+        vcapply(dat$interpolate$max, function(x) {
           sprintf("%s[%s - 1]", rewrite(x),
-                  rewrite(dat$data$elements[[x]]$dimnames$length))))
+                  rewrite(dat$data$elements[[x]]$dimnames$length))
+        }))
     }
   }
 
   len_block <- function(location) {
     if (location == "internal") {
       ## This excludes interpolate_data and ring_buffer
-      keep <- vlapply(dat$data$elements, function(x)
+      keep <- vlapply(dat$data$elements, function(x) {
         x$location == "internal" &&
-        x$storage_type %in% c("double", "int", "bool"))
+          x$storage_type %in% c("double", "int", "bool")
+      })
       contents <- dat$data$elements[keep]
     } else {
       contents <- dat$data$elements[names(dat$data[[location]]$contents)]
@@ -240,11 +243,13 @@ generate_js_core_update_metadata <- function(eqs, dat, rewrite) {
   body$add(len_block("output"))
 
   if (dat$features$has_interpolate) {
-    args_min <- vcapply(dat$interpolate$min, function(x)
-      sprintf("%s[0]", rewrite(x)))
-    args_max <- vcapply(dat$interpolate$max, function(x)
+    args_min <- vcapply(dat$interpolate$min, function(x) {
+      sprintf("%s[0]", rewrite(x))
+    })
+    args_max <- vcapply(dat$interpolate$max, function(x) {
       sprintf("%s[%s - 1]", rewrite(x),
-              rewrite(dat$data$elements[[x]]$dimnames$length)))
+              rewrite(dat$data$elements[[x]]$dimnames$length))
+    })
     array <- function(x) {
       sprintf("[%s]", paste(x, collapse = ", "))
     }

--- a/R/generate_js_equation.R
+++ b/R/generate_js_equation.R
@@ -116,8 +116,9 @@ generate_js_equation_user <- function(eq, data_info, dat, rewrite) {
 
 generate_js_equation_array <- function(eq, data_info, dat, rewrite) {
   lhs <- generate_js_equation_array_lhs(eq, data_info, dat, rewrite)
-  lapply(eq$rhs, function(x)
-    generate_js_equation_array_rhs(x$value, x$index, lhs, rewrite))
+  lapply(eq$rhs, function(x) {
+    generate_js_equation_array_rhs(x$value, x$index, lhs, rewrite)
+  })
 }
 
 

--- a/R/generate_r.R
+++ b/R/generate_r.R
@@ -267,16 +267,18 @@ generate_r_interpolate_t <- function(dat, env, rewrite) {
     return(function(...) NULL)
   }
 
-  args_min <- lapply(dat$interpolate$min, function(x)
-    call("[[", rewrite(x), 1L))
+  args_min <- lapply(dat$interpolate$min, function(x) {
+    call("[[", rewrite(x), 1L)
+  })
   if (length(args_min) == 1L) {
     min <- args_min[[1L]]
   } else {
     min <- as.call(c(list(quote(max)), args_min))
   }
 
-  args_max <- lapply(dat$interpolate$max, function(x)
-    call("[[", rewrite(x), call("length", rewrite(x))))
+  args_max <- lapply(dat$interpolate$max, function(x) {
+    call("[[", rewrite(x), call("length", rewrite(x)))
+  })
   if (length(args_max) == 0L) {
     max <- Inf
   } else if (length(args_max) == 1L) {
@@ -310,10 +312,11 @@ generate_r_set_initial <- function(dat, env, rewrite) {
 
   set_y <- call(
     "if", call("!", call("is.null", as.name(dat$meta$state))),
-    r_expr_block(lapply(dat$data$variable$contents, function(x)
+    r_expr_block(lapply(dat$data$variable$contents, function(x) {
       call("<-", rewrite(x$initial),
            r_extract_variable(x, dat$data$elements, as.name(dat$meta$state),
-                              rewrite)))))
+                              rewrite))
+    })))
   set_t <- call("<-", rewrite(dat$meta$initial_time), as.name(dat$meta$time))
 
   body <- list(set_y, set_t)

--- a/R/generate_r_equation.R
+++ b/R/generate_r_equation.R
@@ -53,8 +53,9 @@ generate_r_equation_inplace <- function(eq, data_info, dat, rewrite) {
 
 generate_r_equation_array <- function(eq, data_info, dat, rewrite) {
   lhs <- generate_r_equation_array_lhs(eq, data_info, dat, rewrite)
-  lapply(eq$rhs, function(x)
-    generate_r_equation_array_rhs(x$value, x$index, lhs, rewrite))
+  lapply(eq$rhs, function(x) {
+    generate_r_equation_array_rhs(x$value, x$index, lhs, rewrite)
+  })
 }
 
 
@@ -143,7 +144,7 @@ generate_r_equation_copy <- function(eq, data_info, dat, rewrite) {
 
   if (data_info$rank == 0) {
     lhs <- call("[[", storage, r_offset_to_position(offset))
-  } else{
+  } else {
     i <- call("seq_len", rewrite(data_info$dimnames$length))
     lhs <- call("[", storage, call("+", offset, i))
   }

--- a/R/ir_parse_config.R
+++ b/R/ir_parse_config.R
@@ -58,10 +58,11 @@ ir_parse_config_include <- function(include, root, source, read_include) {
       x$source, source)
   }
 
-  res <- lapply(filename_full, function(path)
+  res <- lapply(filename_full, function(path) {
     withCallingHandlers(
       read_include(path),
-      error = function(e) message(sprintf("While reading '%s'", path))))
+      error = function(e) message(sprintf("While reading '%s'", path)))
+  })
 
   nms <- unlist(lapply(res, "[[", "names"))
   dups <- unique(nms[duplicated(nms)])

--- a/R/ir_serialise.R
+++ b/R/ir_serialise.R
@@ -173,10 +173,11 @@ ir_serialise_equation_expression_inplace <- function(eq) {
 
 ir_serialise_equation_expression_array <- function(eq) {
   rhs <- function(x) {
-    index <- lapply(x$index, function(i)
+    index <- lapply(x$index, function(i) {
       list(value = ir_serialise_expression(i$value),
            is_range = scalar(i$is_range),
-           index = scalar(i$index)))
+           index = scalar(i$index))
+    })
     list(index = index, value = ir_serialise_expression(x$value))
   }
   list(rhs = lapply(eq$rhs, rhs))
@@ -202,14 +203,16 @@ ir_serialise_delay_continuous <- function(eq) {
   variables <- list(
     length = ir_serialise_expression(eq$delay$variables$length),
     contents = lapply(unname(eq$delay$variables$contents), f_contents))
-  substitutions <- lapply(eq$delay$substitutions, function(x)
-    list(from = scalar(x$from), to = scalar(x$to)))
+  substitutions <- lapply(eq$delay$substitutions, function(x) {
+    list(from = scalar(x$from), to = scalar(x$to))
+  })
   rhs <- list(value = ir_serialise_expression(eq$rhs$value))
   if (!is.null(eq$rhs$index)) {
-    rhs$index <- lapply(eq$rhs$index, function(i)
+    rhs$index <- lapply(eq$rhs$index, function(i) {
       list(value = ir_serialise_expression(i$value),
            is_range = scalar(i$is_range),
-           index = scalar(i$index)))
+           index = scalar(i$index))
+    })
   }
 
   list(rhs = rhs,
@@ -236,10 +239,11 @@ ir_serialise_delay_discrete <- function(eq) {
                 time = ir_serialise_expression(eq$delay$time),
                 default = ir_serialise_expression(eq$delay$default)))
   if (!is.null(eq$rhs$index)) {
-    ret$rhs$index <- lapply(eq$rhs$index, function(i)
+    ret$rhs$index <- lapply(eq$rhs$index, function(i) {
       list(value = ir_serialise_expression(i$value),
            is_range = scalar(i$is_range),
-           index = scalar(i$index)))
+           index = scalar(i$index))
+    })
   }
   ret
 }

--- a/R/misc.R
+++ b/R/misc.R
@@ -43,8 +43,9 @@ read_include_c <- function(filename) {
     stop("Parse error for ", filename)
   }
   name <- sub(re1, "\\1", d[i1])
-  defn <- setNames(vcapply(seq_along(i1), function(k)
-    paste(d[i1[[k]]:i2[[k]]], collapse = "\n")), name)
+  defn <- setNames(vcapply(seq_along(i1), function(k) {
+    paste(d[i1[[k]]:i2[[k]]], collapse = "\n")
+  }), name)
   decl <- sub("^([^{]*?)\\s*\\{.*", "\\1;", defn)
 
   list(

--- a/R/odin_options.R
+++ b/R/odin_options.R
@@ -98,8 +98,9 @@ check_substitutions <- function(substitutions) {
   }
   assert_named(substitutions, TRUE)
   assert_is(substitutions, "list")
-  ok <- vlapply(substitutions, function(x)
-    is.numeric(x) && length(x) == 1L)
+  ok <- vlapply(substitutions, function(x) {
+    is.numeric(x) && length(x) == 1L
+  })
   if (any(!ok)) {
     stop("Invalid entry in substitutions: ",
          paste(squote(names_if(!ok)), collapse = ", "))

--- a/R/support.R
+++ b/R/support.R
@@ -64,13 +64,15 @@ support_transform_variables <- function(y, private) {
     }
     if (any(is_array)) {
       nt <- nrow(y)
-      ret[is_array] <- lapply(which(is_array), function(i)
-        array(y[, i0[[i]]:i1[[i]]], c(nt, ord[[i]])))
+      ret[is_array] <- lapply(which(is_array), function(i) {
+        array(y[, i0[[i]]:i1[[i]]], c(nt, ord[[i]]))
+      })
     }
   } else if (is.array(y)) {
     if (any(is_scalar)) {
-      ret[is_scalar] <- lapply(i0[is_scalar], function(i)
-        adrop(y[, i, , drop = FALSE], 2L))
+      ret[is_scalar] <- lapply(i0[is_scalar], function(i) {
+        adrop(y[, i, , drop = FALSE], 2L)
+      })
     }
     if (has_time) {
       ret[[1]] <- ret[[1]][, 1L, drop = TRUE]
@@ -78,8 +80,9 @@ support_transform_variables <- function(y, private) {
     if (any(is_array)) {
       nt <- nrow(y)
       nr <- dim(y)[[3L]]
-      ret[is_array] <- lapply(which(is_array), function(i)
-        array(y[, i0[[i]]:i1[[i]], ], c(nt, ord[[i]], nr)))
+      ret[is_array] <- lapply(which(is_array), function(i) {
+        array(y[, i0[[i]]:i1[[i]], ], c(nt, ord[[i]], nr))
+      })
     }
   } else {
     if (any(is_scalar)) {
@@ -89,8 +92,9 @@ support_transform_variables <- function(y, private) {
       shape_array <- function(x, ord) {
         if (length(ord) == 1L) unname(x) else array(x, ord)
       }
-      ret[is_array] <- lapply(which(is_array), function(i)
-        shape_array(y[i0[[i]]:i1[[i]]], ord[[i]]))
+      ret[is_array] <- lapply(which(is_array), function(i) {
+        shape_array(y[i0[[i]]:i1[[i]]], ord[[i]])
+      })
     }
   }
   ret

--- a/tests/testthat/examples/lv4_deSolve.R
+++ b/tests/testthat/examples/lv4_deSolve.R
@@ -11,8 +11,9 @@ lv4 <- function() {
   derivs <- function(t, y, .) {
     ## Not much faster, less clear:
     ## > list(r * y * (1 - colSums(t(a) * y)))
-    list(vapply(seq_along(y), function(i)
-      r[i] * y[i] * (1 - sum(a[i, ] * y)), numeric(1)))
+    list(vapply(seq_along(y), function(i) {
+      r[i] * y[i] * (1 - sum(a[i, ] * y))
+    }, numeric(1)))
   }
 
   list(derivs = derivs, initial = initial, t = c(0, 100))

--- a/tests/testthat/test-parse2-general.R
+++ b/tests/testthat/test-parse2-general.R
@@ -53,8 +53,8 @@ test_that("parse array indices", {
 
   ## TODO: Arguably an error; requires more general solution probably
   ## expect_error(
-  ##  odin_parse("deriv(A) <- 1\ninitial(A) <- 1\nx[1:A] <- 1; dim(x) <- 1"),
-  ##             "Array indices may not be time")
+  ## > odin_parse("deriv(A) <- 1\ninitial(A) <- 1\nx[1:A] <- 1; dim(x) <- 1"),
+  ## >            "Array indices may not be time")
 
   expect_error(
     odin_parse_(ex("x[1] <- 1\ny[x] <- 1\ndim(x) <- 1\ndim(y) <- 1")),

--- a/tests/testthat/test-run-interpolation.R
+++ b/tests/testthat/test-run-interpolation.R
@@ -139,8 +139,9 @@ test_that_odin("constant 3d array", {
                "Integration times do not span interpolation")
 
   yy <- mod$run(tt)
-  cmp <- sapply(1:4, function(i)
-    ifelse(tt < 1, 0, ifelse(tt > 2, i, i * (tt - 1))))
+  cmp <- sapply(1:4, function(i) {
+    ifelse(tt < 1, 0, ifelse(tt > 2, i, i * (tt - 1)))
+  })
   tol <- variable_tolerance(mod, 1e-5, js = 5e-4)
   expect_equal(unname(yy[, -1]), cmp, tolerance = tol)
 })
@@ -416,8 +417,9 @@ test_that_odin("user sized interpolation, 2d", {
 
   tt <- seq(0, 3, length.out = 301)
   yy <- mod$run(tt)
-  cmp <- sapply(1:4, function(i)
-    ifelse(tt < 1, 0, ifelse(tt > 2, i, i * (tt - 1))))
+  cmp <- sapply(1:4, function(i) {
+    ifelse(tt < 1, 0, ifelse(tt > 2, i, i * (tt - 1)))
+  })
   tol <- variable_tolerance(mod, 1e-5, js = 1e-3)
   expect_equal(unname(yy[, -1]), cmp, tolerance = tol)
 })

--- a/tests/testthat/test-support.R
+++ b/tests/testthat/test-support.R
@@ -78,8 +78,9 @@ test_that("multivariate hypergeometric distribution", {
   expect_equal(colMeans(res), n * k / N, tolerance = 0.05)
 
   ## Variance and covariance
-  expected <- outer(k, k, function(ki, kj)
-    - n * (N - n) / (N - 1) * ki / N * kj / N)
+  expected <- outer(k, k, function(ki, kj) {
+    - n * (N - n) / (N - 1) * ki / N * kj / N
+  })
   diag(expected) <- n * (N - n) / (N - 1) * k / N * (1 - k / N)
   expect_equal(cov(res), expected, tolerance = 0.05)
 })

--- a/vignettes/discrete.Rmd
+++ b/vignettes/discrete.Rmd
@@ -175,7 +175,8 @@ We start by loading the `odin` code for a discrete, stochastic SIR
 model:
 
 ``` {r load_sir}
-path_sir_model <- system.file("examples/discrete_deterministic_sir.R", package = "odin")
+path_sir_model <- system.file("examples/discrete_deterministic_sir.R",
+                              package = "odin")
 ```
 
 ``` {r echo = FALSE, results = "asis"}
@@ -227,7 +228,8 @@ The stochastic equivalent of the previous model can be formulated
 in `odin` as follows:
 
 ``` {r load_sir_s}
-path_sir_model_s <- system.file("examples/discrete_stochastic_sir.R", package = "odin")
+path_sir_model_s <- system.file("examples/discrete_stochastic_sir.R",
+                                package = "odin")
 ```
 
 ``` {r echo = FALSE, results = "asis"}
@@ -258,7 +260,8 @@ is of limited interest. As an alternative, we can generate a large
 number of replicates using arrays for each compartment:
 
 ``` {r }
-path_sir_model_s_a <- system.file("examples/discrete_stochastic_sir_arrays.R", package = "odin")
+path_sir_model_s_a <- system.file("examples/discrete_stochastic_sir_arrays.R",
+                                  package = "odin")
 ```
 
 ``` {r echo = FALSE, results = "asis"}
@@ -344,7 +347,8 @@ $$
 The formulation of the model in `odin` is:
 
 ``` {r load_seirds}
-path_seirds_model <- system.file("examples/discrete_stochastic_seirds.R", package = "odin")
+path_seirds_model <- system.file("examples/discrete_stochastic_seirds.R",
+                                 package = "odin")
 ```
 
 ``` {r echo = FALSE, results = "asis"}
@@ -357,14 +361,16 @@ seirds_generator
 x <- seirds_generator$new()
 
 
-seirds_col <- c("#8c8cd9", "#e67300", "#d279a6", "#ff4d4d", "#999966", "#660000")
+seirds_col <- c("#8c8cd9", "#e67300", "#d279a6", "#ff4d4d", "#999966",
+                "#660000")
 
 set.seed(1)
 x_res <- x$run(0:365)
 par(mar = c(4.1, 5.1, 0.5, 0.5), las = 1)
 matplot(x_res[, 1], x_res[, -1], xlab = "Time", ylab = "Number of individuals",
         type = "l", col = seirds_col, lty = 1)
-legend("left", lwd = 1, col = seirds_col, legend = c("S", "E", "Ir", "Id", "R", "D"), bty = "n")
+legend("left", lwd = 1, col = seirds_col,
+       legend = c("S", "E", "Ir", "Id", "R", "D"), bty = "n")
 ```
 
 

--- a/vignettes/functions.Rmd
+++ b/vignettes/functions.Rmd
@@ -24,8 +24,9 @@ render <- function(x) {
       ret <- sprintf("**%s**", el$title)
     }
     if (!is.null(el$examples)) {
-      examples <- vcapply(el$examples, function(ex)
-        sprintf("`%s` &rarr; `%s`", ex[[1]], ex[[2]]))
+      examples <- vcapply(el$examples, function(ex) {
+        sprintf("`%s` &rarr; `%s`", ex[[1]], ex[[2]])
+      })
       ret <- sprintf("%s (e.g., %s)", ret, paste(examples, collapse = "; "))
     }
     ret


### PR DESCRIPTION
The new version of lintr changes behaviour of some linters, this PR fixes the newly reported lint.

I'm not a huge fan of the requirement for braces on anonymous functions, but there's no way of selectively turning that part off. The nolint tags for the 1:x expressions are because they never get evaluated by R but get used as part of the DSL so we need them to use the 1:x form, not the seq_len(x) form