### PR TITLE
Minor typos

### DIFF
--- a/R/common.R
+++ b/R/common.R
@@ -183,7 +183,7 @@ rm(.join)
 FUNCTIONS_NARY <-
   names(which(vapply(FUNCTIONS, function(x) x[[length(x)]] == Inf, logical(1))))
 
-## This will probab;ly change later, as it should probably be more
+## This will probably change later, as it should probably be more
 ## configurable, bit this way we avoid a magic number
 DEFAULT_HISTORY_SIZE <- 10000L
 

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -1576,10 +1576,10 @@ ir_parse_expr_rhs_check_usage <- function(rhs, line, source) {
       if (length(n) > 1L) {
         if (nargs < n[[1L]] || nargs > n[[2L]]) {
           if (is.finite(n[[2L]])) {
-            throw("Expected %d-%d arguments in %s call, but recieved %d",
+            throw("Expected %d-%d arguments in %s call, but received %d",
                   n[[1L]], n[[2L]], nm, nargs)
           } else {
-            throw("Expected %d or more arguments in %s call, but recieved %d",
+            throw("Expected %d or more arguments in %s call, but received %d",
                   n[[1L]], nm, nargs)
           }
         }
@@ -1590,7 +1590,7 @@ ir_parse_expr_rhs_check_usage <- function(rhs, line, source) {
             ## problem a little clearer.
             throw("All if statements must have an else clause")
           } else {
-            throw("Expected %d %s in %s call, but recieved %d",
+            throw("Expected %d %s in %s call, but received %d",
                   n, ngettext(n, "argument", "arguments"), nm, nargs)
           }
         }

--- a/R/ir_parse_config.R
+++ b/R/ir_parse_config.R
@@ -85,7 +85,7 @@ ir_parse_config_custom <- function(x, source) {
 
   ## Is there any other validation that can really be done? We could
   ## require that custom cases conform to particular types or are
-  ## unique? For now we'll be really leniant since we don't document
+  ## unique? For now we'll be really lenient since we don't document
   ## this as a public interface yet.
   name <- vcapply(x, function(el) el$lhs$name_lhs)
   value <- lapply(x, function(el) el$rhs$value)
@@ -111,7 +111,7 @@ ir_parse_config1 <- function(eq, source, custom) {
   } else {
     if (storage.mode(value) != expected_type) {
       ir_parse_error(sprintf(
-        "Expected a %s for config(%s) but recieved a %s",
+        "Expected a %s for config(%s) but received a %s",
         expected_type, target, storage.mode(value)),
         eq$source, source)
     }

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Note that this includes initial conditions; all odin models include specificatio
 This generates an object that can be used to integrate the set of differential equations, by default starting at the initial conditions specified above (though custom initial conditions can be given).  The equations are translated into C, compiled, loaded, and bundled into an object.  `lorenz` here is a function that generates an instance of the model.
 
 ```r
-mod <- lorenz()
+mod <- lorenz$new()
 t <- seq(0, 100, length.out = 50000)
 y <- mod$run(t)
 ```

--- a/tests/testthat/test-parse2-config.R
+++ b/tests/testthat/test-parse2-config.R
@@ -17,11 +17,11 @@ test_that("config(base)", {
                "Expected a single config(base) option",
                fixed = TRUE, class = "odin_error")
   expect_error(odin_parse("config(base) <- foo;"),
-               "Expected a character for config(base) but recieved a symbol",
+               "Expected a character for config(base) but received a symbol",
                fixed = TRUE, class = "odin_error")
   expect_error(
     odin_parse("config(base) <- 1;"),
-    "Expected a character for config(base) but recieved a double",
+    "Expected a character for config(base) but received a double",
     fixed = TRUE, class = "odin_error")
 
   ## some invalid identifiers:


### PR DESCRIPTION
Thanks for accepting my previous issue. I'm exploring `odin`. I find it very lovely.

Found more typos. This time a PR is submitted instead.

I'd like to also hijack this PR and ask about this:
```r
odin::odin({
  update(S) <- -beta * S * I
  update(I) <- +beta * S * I
  N <- S + I

  beta <- user(0.005)
  initial(S) <- 100.0
  initial(I) <- 1.0
}, verbose = TRUE, validate = TRUE, target = "c", pretty = TRUE,
  skip_cache = TRUE) ->
  model_generator
model_generator$new() -> model
model$run(seq.default(0, 5, length.out = 25))
```
```
Error: Expected integer input for 'step'
Called from: as_integer(step)
```
Why is that? Passing numeric steps for the `lorenz` example works.
```r
> traceback()
4: stop(sprintf("Expected integer input for '%s'", name), call. = FALSE)
3: as_integer(step)
2: private$odin$wrapper_run_discrete(self, private, step, y, ..., 
       use_names = use_names) at odin.R#100
1: model$run(seq.default(0, 5, length.out = 25))
```

