### PR TITLE
Proof-of-concept data/compare in odin

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.4.7
+Version: 1.5.0
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/R/common.R
+++ b/R/common.R
@@ -21,8 +21,9 @@ RING <- "odin_ring"
 ## variables) but that needs checking too.  Not 100% sure this is done
 ## on the lhs index bits.  Probably need to standardise that at some
 ## point.
-SPECIAL_LHS <- c("initial", "deriv", "update", "output", "dim", "config")
-SPECIAL_RHS <- c("user", "interpolate", "delay")
+SPECIAL_LHS <- c("initial", "deriv", "update", "output", "dim", "config",
+                 "compare")
+SPECIAL_RHS <- c("user", "interpolate", "delay", "data")
 INDEX <- c("i", "j", "k", "l", "i5", "i6", "i7", "i8") # TODO: make open
 INTERNAL <- "internal"
 

--- a/R/generate_c.R
+++ b/R/generate_c.R
@@ -28,6 +28,9 @@ generate_c_code <- function(dat, options, package) {
   if (dat$features$mixed) {
     stop("Models that mix deriv() and update() are not supported")
   }
+  if (dat$features$has_compare || dat$features$has_data) {
+    stop("data() and compare() not supported")
+  }
 
   if (dat$features$has_delay) {
     dat$data$elements[[dat$meta$c$use_dde]] <-

--- a/R/generate_js.R
+++ b/R/generate_js.R
@@ -4,6 +4,9 @@ generate_js <- function(ir, options) {
   if (dat$features$mixed) {
     stop("Models that mix deriv() and update() are not supported")
   }
+  if (dat$features$has_compare || dat$features$has_data) {
+    stop("data() and compare() not supported")
+  }
 
   rewrite <- function(x) {
     generate_js_sexp(x, dat$data, dat$meta)

--- a/R/generate_r.R
+++ b/R/generate_r.R
@@ -2,6 +2,9 @@ generate_r <- function(dat, options) {
   if (dat$features$mixed) {
     stop("Models that mix deriv() and update() are not supported")
   }
+  if (dat$features$has_compare || dat$features$has_data) {
+    stop("data() and compare() not supported")
+  }
 
   if (dat$features$has_delay) {
     ## We're going to need an additional bit of internal data here,

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -707,8 +707,6 @@ ir_parse_expr <- function(expr, line, source) {
     type <- "dim"
   } else if (identical(lhs$special, "config")) {
     type <- "config"
-  } else if (identical(lhs$special, "compare")) {
-    type <- "compare"
   } else if (lhs$type == "expression_scalar") {
     type <- "expression_scalar"
   } else if (lhs$type == "expression_array") {

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -1160,7 +1160,7 @@ ir_parse_expr_rhs_delay <- function(rhs, line, source) {
 
 ir_parse_equations <- function(eqs) {
   type <- vcapply(eqs, "[[", "type")
-  eqs[!(type %in% c("null", "config"))]
+  eqs[!(type %in% c("null", "config", "data"))]
 }
 
 

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -1953,7 +1953,7 @@ ir_parse_compare <- function(eq, line, source) {
 
 ## TODO: these (for now at least) don't sanitise args. The list
 ## effectively depends on dust, but that feels suboptimal (e.g., for
-## the js target). Things like negative binomial will be a trick
+## the js target). Things like negative binomial is a trick
 ## because there are two different forms.  We'll expand support in
 ## dust fairly promptly I'd expect.
 ir_parse_compare_rhs <- function(expr, line, source) {
@@ -1964,7 +1964,8 @@ ir_parse_compare_rhs <- function(expr, line, source) {
   }
   stopifnot(is.name(expr[[1]]))
   distribution <- deparse(expr[[1]])
-  valid <- c("normal", "binomial", "negative_binomial", "beta_binomial",
+  valid <- c("normal", "binomial", "negative_binomial_mu",
+             "negative_binomial_prob", "beta_binomial",
              "poisson")
   if (!(distribution %in% valid)) {
     ir_parse_error(
@@ -1973,7 +1974,7 @@ ir_parse_compare_rhs <- function(expr, line, source) {
       line, source)
   }
 
-  ir_parse_expr_rhs_check_usage(expr)
+  ir_parse_expr_rhs_check_usage(expr, line, source)
 
   args <- as.list(expr[-1])
   depends <- join_deps(lapply(args, find_symbols))

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -943,14 +943,16 @@ ir_parse_expr_check_lhs_name <- function(lhs, special, line, source) {
 
   name <- deparse(lhs)
 
-  if (name %in% RESERVED) {
-    ir_parse_error(sprintf("Reserved name '%s' for lhs", name), line, source)
-  }
-  re <- sprintf("^(%s)_.*", paste(RESERVED_PREFIX, collapse = "|"))
-  if (grepl(re, name)) {
-    ir_parse_error(sprintf("Variable name cannot start with '%s_'",
-                           sub(re, "\\1", name)),
-                   line, source)
+  if (!identical(special, "config")) {
+    if (name %in% RESERVED) {
+      ir_parse_error(sprintf("Reserved name '%s' for lhs", name), line, source)
+    }
+    re <- sprintf("^(%s)_.*", paste(RESERVED_PREFIX, collapse = "|"))
+    if (grepl(re, name)) {
+      ir_parse_error(sprintf("Variable name cannot start with '%s_'",
+                             sub(re, "\\1", name)),
+                     line, source)
+    }
   }
 
   name

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -1939,6 +1939,11 @@ ir_parse_compare <- function(eq, line, source) {
 }
 
 
+## TODO: these (for now at least) don't sanitise args. The list
+## effectively depends on dust, but that feels suboptimal (e.g., for
+## the js target). Things like negative binomial will be a trick
+## because there are two different forms.  We'll expand support in
+## dust fairly promptly I'd expect.
 ir_parse_compare_rhs <- function(expr, line, source) {
   if (!is.recursive(expr)) {
     ir_parse_error(
@@ -1947,7 +1952,8 @@ ir_parse_compare_rhs <- function(expr, line, source) {
   }
   stopifnot(is.name(expr[[1]]))
   distribution <- deparse(expr[[1]])
-  valid <- c("normal", "binomial")
+  valid <- c("normal", "binomial", "negative_binomial", "beta_binomial",
+             "poisson")
   if (!(distribution %in% valid)) {
     ir_parse_error(
       sprintf("Expected rhs to be a valid distribution (%s)",

--- a/R/ir_parse.R
+++ b/R/ir_parse.R
@@ -153,7 +153,7 @@ ir_parse_data <- function(eqs, packing, stage, source) {
   is_alloc <- vlapply(eqs, function(x) {
     x$type == "alloc" && x$name != x$lhs$name_lhs
   })
-  i <- !(is_alloc | type %in% c("copy", "config", "compare", "data"))
+  i <- !(is_alloc | type %in% c("copy", "config", "compare"))
 
   elements <- lapply(eqs[i], ir_parse_data_element, stage)
   names(elements) <- vcapply(elements, "[[", "name")
@@ -180,7 +180,9 @@ ir_parse_data_element <- function(x, stage) {
 
   stage <- stage[[x$name]]
 
-  if (is.null(x$lhs$special)) {
+  if (x$type == "data") {
+    location <- "data"
+  } else if (is.null(x$lhs$special)) {
     if (rank == 0L && stage == STAGE_TIME) {
       location <- "transient"
     } else {

--- a/R/ir_serialise.R
+++ b/R/ir_serialise.R
@@ -137,7 +137,9 @@ ir_serialise_equation <- function(eq) {
     interpolate = ir_serialise_equation_interpolate(eq),
     user = ir_serialise_equation_user(eq),
     data = ir_serialise_equation_data(eq),
-    stop("odin bug"))
+    compare = ir_serialise_equation_compare(eq),
+    stop(sprintf("Can't serialise unknown equation type '%s' [odin bug]",
+                 eq$type)))
   c(base, extra)
 }
 
@@ -199,6 +201,13 @@ ir_serialise_equation_user <- function(eq) {
 
 ir_serialise_equation_data <- function(eq) {
   list(data = list(type = scalar(eq$data$type)))
+}
+
+
+ir_serialise_equation_compare <- function(eq) {
+  compare <- list(distribution = scalar(eq$rhs$distribution),
+                  args = lapply(eq$rhs$args, ir_serialise_expression))
+  list(compare = compare)
 }
 
 

--- a/R/ir_serialise.R
+++ b/R/ir_serialise.R
@@ -136,6 +136,7 @@ ir_serialise_equation <- function(eq) {
     expression_inplace = ir_serialise_equation_expression_inplace(eq),
     interpolate = ir_serialise_equation_interpolate(eq),
     user = ir_serialise_equation_user(eq),
+    data = ir_serialise_equation_data(eq),
     stop("odin bug"))
   c(base, extra)
 }
@@ -193,6 +194,11 @@ ir_serialise_equation_user <- function(eq) {
                    dim = scalar(eq$user$dim),
                    min = ir_serialise_expression(eq$user$min),
                    max = ir_serialise_expression(eq$user$max)))
+}
+
+
+ir_serialise_equation_data <- function(eq) {
+  list(data = list(type = scalar(eq$data$type)))
 }
 
 

--- a/R/ir_serialise.R
+++ b/R/ir_serialise.R
@@ -199,11 +199,6 @@ ir_serialise_equation_user <- function(eq) {
 }
 
 
-ir_serialise_equation_data <- function(eq) {
-  list(data = list(type = scalar(eq$data$type)))
-}
-
-
 ir_serialise_equation_compare <- function(eq) {
   compare <- list(distribution = scalar(eq$rhs$distribution),
                   args = lapply(eq$rhs$args, ir_serialise_expression))

--- a/inst/schema.json
+++ b/inst/schema.json
@@ -60,6 +60,7 @@
                     "interpolate",
                     "user",
                     "data",
+                    "compare",
                     "expression_array",
                     "expression_inplace",
                     "expression_scalar"
@@ -345,6 +346,7 @@
                         {"$ref": "#/definitions/equation_alloc_ring"},
                         {"$ref": "#/definitions/equation_user"},
                         {"$ref": "#/definitions/equation_data"},
+                        {"$ref": "#/definitions/equation_compare"},
                         {"$ref": "#/definitions/equation_expression_array"},
                         {"$ref": "#/definitions/equation_expression_inplace"},
                         {"$ref": "#/definitions/equation_expression_scalar"},
@@ -681,6 +683,35 @@
             "additionalProperties": false
         },
 
+        "equation_compare": {
+            "type": "object",
+            "properties": {
+                "type": {"const": "compare"},
+                "name": {},
+                "source": {},
+                "depends": {},
+                "lhs": {},
+                "compare": {
+                    "type": "object",
+                    "properties": {
+                        "distribution": {
+                            "type": "string"
+                        },
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/sexpression"
+                            }
+                        }
+                    },
+                    "required": ["distribution", "args"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["type", "compare"],
+            "additionalProperties": false
+        },
+
         "equation_delay_continuous": {
             "type": "object",
             "properties": {
@@ -766,6 +797,7 @@
                 "initial": { "$ref": "#/definitions/component" },
                 "rhs": { "$ref": "#/definitions/component" },
                 "output": { "$ref": "#/definitions/component" },
+                "compare": { "$ref": "#/definitions/component" },
                 "update_stochastic": { "$ref": "#/definitions/component" }
             },
             "required": ["create", "user", "initial", "rhs", "output"],

--- a/inst/schema.json
+++ b/inst/schema.json
@@ -59,6 +59,7 @@
                     "delay_discrete",
                     "interpolate",
                     "user",
+                    "data",
                     "expression_array",
                     "expression_inplace",
                     "expression_scalar"
@@ -196,6 +197,8 @@
                 "has_array": { "type": "boolean" },
                 "has_output": { "type": "boolean" },
                 "has_user": { "type": "boolean" },
+                "has_data": { "type": "boolean" },
+                "has_compare": { "type": "boolean" },
                 "has_delay": { "type": "boolean" },
                 "has_interpolate": { "type": "boolean" },
                 "has_stochastic": { "type": "boolean" },
@@ -341,6 +344,7 @@
                         {"$ref": "#/definitions/equation_alloc_interpolate"},
                         {"$ref": "#/definitions/equation_alloc_ring"},
                         {"$ref": "#/definitions/equation_user"},
+                        {"$ref": "#/definitions/equation_data"},
                         {"$ref": "#/definitions/equation_expression_array"},
                         {"$ref": "#/definitions/equation_expression_inplace"},
                         {"$ref": "#/definitions/equation_expression_scalar"},
@@ -651,6 +655,29 @@
                 }
             },
             "required": ["type", "user"],
+            "additionalProperties": false
+        },
+
+        "equation_data": {
+            "type": "object",
+            "properties": {
+                "type": {"const": "data"},
+                "name": {},
+                "source": {},
+                "depends": {},
+                "lhs": {},
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "const": "real_type"
+                        }
+                    },
+                    "required": ["type"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["type", "data"],
             "additionalProperties": false
         },
 

--- a/inst/schema.json
+++ b/inst/schema.json
@@ -59,7 +59,6 @@
                     "delay_discrete",
                     "interpolate",
                     "user",
-                    "data",
                     "compare",
                     "expression_array",
                     "expression_inplace",
@@ -345,7 +344,6 @@
                         {"$ref": "#/definitions/equation_alloc_interpolate"},
                         {"$ref": "#/definitions/equation_alloc_ring"},
                         {"$ref": "#/definitions/equation_user"},
-                        {"$ref": "#/definitions/equation_data"},
                         {"$ref": "#/definitions/equation_compare"},
                         {"$ref": "#/definitions/equation_expression_array"},
                         {"$ref": "#/definitions/equation_expression_inplace"},
@@ -657,29 +655,6 @@
                 }
             },
             "required": ["type", "user"],
-            "additionalProperties": false
-        },
-
-        "equation_data": {
-            "type": "object",
-            "properties": {
-                "type": {"const": "data"},
-                "name": {},
-                "source": {},
-                "depends": {},
-                "lhs": {},
-                "data": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "const": "real_type"
-                        }
-                    },
-                    "required": ["type"],
-                    "additionalProperties": false
-                }
-            },
-            "required": ["type", "data"],
             "additionalProperties": false
         },
 

--- a/inst/schema.json
+++ b/inst/schema.json
@@ -44,7 +44,7 @@
 
             "location": {
                 "type": "string",
-                "enum": ["transient", "internal", "variable", "output"]
+                "enum": ["transient", "internal", "variable", "output", "data"]
             },
 
             "equation_type": {

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -164,7 +164,7 @@ test_that_odin("mixed models not supported by any odin target", {
 test_that_odin("compare and data not supported by any odin target", {
   expect_error(odin({
     initial(x) <- 0
-    deriv(x) <- a
+    update(x) <- a
     initial(a) <- 0
     update(a) <- a + 1
     y <- data()
@@ -174,7 +174,7 @@ test_that_odin("compare and data not supported by any odin target", {
 
   expect_error(odin({
     initial(x) <- 0
-    deriv(x) <- a
+    update(x) <- a
     initial(a) <- 0
     update(a) <- a + 1
     compare(a) ~ normal(0, 1)

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -160,4 +160,27 @@ test_that_odin("mixed models not supported by any odin target", {
   fixed = TRUE)
 })
 
+
+test_that_odin("compare and data not supported by any odin target", {
+  expect_error(odin({
+    initial(x) <- 0
+    deriv(x) <- a
+    initial(a) <- 0
+    update(a) <- a + 1
+    y <- data()
+  }),
+  "data() and compare() not supported",
+  fixed = TRUE)
+
+  expect_error(odin({
+    initial(x) <- 0
+    deriv(x) <- a
+    initial(a) <- 0
+    update(a) <- a + 1
+    compare(a) ~ normal(0, 1)
+  }),
+  "data() and compare() not supported",
+  fixed = TRUE)
+})
+
 unload_dlls()

--- a/tests/testthat/test-parse2-data.R
+++ b/tests/testthat/test-parse2-data.R
@@ -14,6 +14,18 @@ test_that("Can parse with a data element", {
 })
 
 
+test_that("Can parse with a data element", {
+  expect_error(
+    odin_parse({
+      initial(x) <- 1
+      update(x) <- rnorm(0, 0.1)
+      d <- data(1, 2)
+    }),
+    "Calls to data() must have no arguments",
+    fixed = TRUE)
+})
+
+
 test_that("Can parse with a compare expression", {
   ir <- odin_parse({
     initial(x) <- 1

--- a/tests/testthat/test-parse2-data.R
+++ b/tests/testthat/test-parse2-data.R
@@ -34,3 +34,42 @@ test_that("Can parse with a compare expression", {
          compare = list(distribution = "normal",
                         args = list(0, 1))))
 })
+
+
+test_that("compare expressions must use ~ not <-", {
+  expect_error(
+    odin_parse({
+      initial(x) <- 1
+      update(x) <- rnorm(0, 0.1)
+      d <- data()
+      compare(d) <- normal(0, 1)
+    }),
+    "All compare() expressions must use '~' and not '<-' or '='",
+    fixed = TRUE)
+})
+
+
+test_that("compare expressions must be a call", {
+  expect_error(
+    odin_parse({
+      initial(x) <- 1
+      update(x) <- rnorm(0, 0.1)
+      d <- data()
+      compare(d) ~ normal
+    }),
+    "Expected rhs of compare() expression to be a call",
+    fixed = TRUE)
+})
+
+
+test_that("compare expressions must be a call", {
+  expect_error(
+    odin_parse({
+      initial(x) <- 1
+      update(x) <- rnorm(0, 0.1)
+      d <- data()
+      compare(d) ~ exciting(0, 1)
+    }),
+    "Expected rhs to be a valid distribution",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-parse2-data.R
+++ b/tests/testthat/test-parse2-data.R
@@ -11,6 +11,10 @@ test_that("Can parse with a data element", {
     list(name = "d", type = "data", source = list(3),
          depends = NULL, lhs = "d", data = list(type = "real_type")))
   expect_true(d$features$has_data)
+  expect_mapequal(
+    d$data$elements$d,
+    list(name = "d", location = "data", storage_type = "double",
+         rank = 0L, dimnames = NULL, stage = "time"))
 })
 
 

--- a/tests/testthat/test-parse2-data.R
+++ b/tests/testthat/test-parse2-data.R
@@ -115,3 +115,16 @@ test_that("compare expressions must be a call", {
     "Expected rhs to be a valid distribution",
     fixed = TRUE)
 })
+
+
+test_that("negative binomial still can't use args", {
+  expect_error(
+    odin_parse({
+      initial(x) <- 1
+      update(x) <- rnorm(0, 0.1)
+      d <- data()
+      compare(d) ~ normal(mean = 0, sd = 1)
+    }),
+    "Named argument calls not supported in odin",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-parse2-data.R
+++ b/tests/testthat/test-parse2-data.R
@@ -1,0 +1,36 @@
+test_that("Can parse with a data element", {
+  ir <- odin_parse({
+    initial(x) <- 1
+    update(x) <- rnorm(0, 0.1)
+    d <- data()
+  })
+  d <- ir_deserialise(ir)
+  expect_length(d$equations, 3)
+  expect_mapequal(
+    d$equations$d,
+    list(name = "d", type = "data", source = list(3),
+         depends = NULL, lhs = "d", data = list(type = "real_type")))
+  expect_true(d$features$has_data)
+})
+
+
+test_that("Can parse with a compare expression", {
+  ir <- odin_parse({
+    initial(x) <- 1
+    update(x) <- rnorm(0, 0.1)
+    d <- data()
+    compare(d) ~ normal(0, 1)
+  })
+  d <- ir_deserialise(ir)
+
+  expect_length(d$equations, 4)
+  expect_mapequal(
+    d$equations$compare_d,
+    list(name = "compare_d",
+         type = "compare",
+         source = list(4),
+         depends = list(functions = character(), variables = "d"),
+         lhs = "d",
+         compare = list(distribution = "normal",
+                        args = list(0, 1))))
+})

--- a/tests/testthat/test-parse2-data.R
+++ b/tests/testthat/test-parse2-data.R
@@ -5,11 +5,7 @@ test_that("Can parse with a data element", {
     d <- data()
   })
   d <- ir_deserialise(ir)
-  expect_length(d$equations, 3)
-  expect_mapequal(
-    d$equations$d,
-    list(name = "d", type = "data", source = list(3),
-         depends = NULL, lhs = "d", data = list(type = "real_type")))
+  expect_length(d$equations, 2)
   expect_true(d$features$has_data)
   expect_mapequal(
     d$data$elements$d,
@@ -27,7 +23,7 @@ test_that("Can parse with a compare expression", {
   })
   d <- ir_deserialise(ir)
 
-  expect_length(d$equations, 4)
+  expect_length(d$equations, 3)
   expect_mapequal(
     d$equations$compare_d,
     list(name = "compare_d",

--- a/tests/testthat/test-parse2-data.R
+++ b/tests/testthat/test-parse2-data.R
@@ -48,6 +48,36 @@ test_that("Can parse with a compare expression", {
 })
 
 
+test_that("correct components", {
+  ir <- odin_parse({
+    initial(x) <- 1
+    update(x) <- rnorm(0, 2 * sd)
+    d <- data()
+    sd <- user()
+    compare(d) ~ normal(x, sd)
+  })
+  d <- ir_deserialise(ir)
+  expect_equal(
+    d$components$update,
+    list(variables = character(), equations = character()))
+  expect_equal(
+    d$components$compare,
+    list(variables = "x", equations = "compare_d"))
+})
+
+
+test_that("can't refer to data outside of compare", {
+  expect_error(
+    odin_parse({
+      initial(x) <- 1
+      update(x) <- rnorm(0, 2 * d)
+      d <- data()
+    }),
+    "Data ('d') may only be referred to in compare expressions",
+    fixed = TRUE)
+})
+
+
 test_that("compare expressions must use ~ not <-", {
   expect_error(
     odin_parse({


### PR DESCRIPTION
This PR provides parse support for the new compare syntax (see https://github.com/mrc-ide/odin.dust/issues/130 and the corresponding PR https://github.com/mrc-ide/odin.dust/issues/131). I doubt we'll ever support this in O.G. odin, but we will eventually in the js version which uses a dust-like target.

Here, we just try and wrangle the input and do as little validation as possible. One nice thing about this approach is that all the bits for checking unused variables etc come along for free.

Note that this is intentionally undocumented; we'll document it properly in odin.dust when supported, and it really will just represent a ghost feature in odin

Alex; just adding you here as a FYI, but any comments very welcome

A reminder of the order of PRs:

* compare/data definition within the odin DSL (you are here)
* generate code from this in odin dust (draft PR linked above)
* new support in dust for models that can produce their own derivatives
* generate code using this compare dsl to target this new dust support