### PR TITLE
Fix for CRAN, following change of behaviour of is.atomic(NULL)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin
 Title: ODE Generation and Integration
-Version: 1.5.8
+Version: 1.5.9
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Thibaut", "Jombart", role = "ctb"),

--- a/R/ir_serialise.R
+++ b/R/ir_serialise.R
@@ -265,6 +265,8 @@ ir_serialise_expression <- function(expr) {
     jsonlite::unbox(as.character(expr))
   } else if (is.atomic(expr)) {
     jsonlite::unbox(expr)
+  } else if (is.null(expr)) {
+    NULL
   } else if (is.call(expr)) {
     c(list(jsonlite::unbox(as.character(expr[[1L]]))),
       lapply(expr[-1L], ir_serialise_expression))

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ In other languages:
 
 * [`Paraiso`](https://hackage.haskell.org/package/Paraiso) in Haskell
 * [`VFGEN`](https://github.com/WarrenWeckesser/vfgen) in C++
-* [`pygom`](https://github.com/PublicHealthEngland/pygom) in Python for solving compartmental models
+* [`pygom`](https://github.com/ukhsa-collaboration/pygom) in Python for solving compartmental models
 
 ## Installation
 


### PR DESCRIPTION
This PR fixes the breaking change coming from R:

> r85227 | maechler | 2023-09-28 09:38:16 +0200 (Thu, 28 Sep 2023) | 1 line
> is.atomic(NULL) now is FALSE
> 
> Please see
> <https://stat.ethz.ch/pipermail/r-devel/2023-September/082892.html> for
> more information and guidance.
> 
> Please correct before 2023-10-14 to safely retain your package on CRAN.

which is producing errors like

```
     ══ Failed tests ════════════════════════════════════════════════════════════════
     ── Error ('test-interface.R:19:3'): n_history is configurable ──────────────────
     Error in `ir_serialise_expression(eq$delay$default)`: unhandled expression [odin bug]
     Backtrace:
     ▆
     1. └─odin::odin(...) at test-interface.R:19:2
     2. └─odin::odin_(...)
     3. └─odin::odin_parse_(x, options)
     4. └─odin:::ir_parse(x, options, type)
     5. └─odin:::ir_serialise(ret, options$pretty)
     6. └─odin:::ir_serialise_equations(dat$equations)
     7. └─base::lapply(unname(equations), ir_serialise_equation)
     8. └─odin (local) FUN(X[[i]], ...)
     9. └─odin:::ir_serialise_delay_continuous(eq)
     10. └─odin:::ir_serialise_expression(eq$delay$default)
```
